### PR TITLE
add hyperkube v1.10.0-beta.0

### DIFF
--- a/images.go
+++ b/images.go
@@ -97,6 +97,10 @@ var Images = []Image{
 				Sha: "7653dfb091e9524ecb1c2c472ec27e9d2e0ff9addc199d91b5c532a2cdba5b9e",
 				Tag: "v1.9.3",
 			},
+			Tag{
+				Sha: "e3245f0d94b6fdd77a8bc08dd5f8b52dbea7e1e2603d2a3dbb56bd253f602e90",
+				Tag: "v1.10.0-beta.0",
+			},
 		},
 	},
 	Image{


### PR DESCRIPTION
1.10 supports azure vmss. Unfortunately beta.0 yet.