### PR TITLE
Improves image tag check with quay api

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ go test
 
 ## About
 
-`retagger` is used to move all images required by Giant Swarm to our registry, while maintaining integrity of images - that is, we should be able to determine where all images came from. The alternative is manually retagging and pushing images, which means we lose a degree of accountability.
+`retagger` is used to move all images required by Giant Swarm to our Quay.io registry, while maintaining integrity of images - that is, we should be able to determine where all images came from. The alternative is manually retagging and pushing images, which means we lose a degree of accountability.
 
 A list of images (see `images.go`) is maintained, with a list of sha hashes and tag pairs. The `retagger` goes through each image, and then each sha hash and tag pair. The image is pulled by the sha hash, to overcome issues where a specific tag is rewritten, retagged with the tag, and pushed to our registry.
 
 The image name is also rewritten. For example, `quay.io/coreos/hyperkube` becomes `quay.io/giantswarm/hyperkube`, `prom/prometheus` becomes `quay.io/giantswarm/prometheus`.
 
-We attempt to pull the image from our registry first, to avoid unnecessary pulling of other images.
+We use the Quay.io API to check if an image has already been retagged, to avoid unnecessary work.
 
-We currently only support public images, both for pulling and pushing.
+We currently only support public images for retagging.
 
 The `retagger` works inside a CI build. On merges to master, the binary is executed. The workflow is to add a new image / sha tag pair in a PR, review it, and then merge. The `retagger` will take care that the image is handled. Users will still need to create repositories in the registry.
 
@@ -46,7 +46,8 @@ With tags, use the tag from the third party image. For example, the above image 
 
 ### Running
 
-The environment variables `REGISTRY`, `REGISTRY_ORGANISATION`, `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` need to be set.
+The environment variables `REGISTRY`, `REGISTRY_ORGANISATION`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, and `QUAY_TOKEN` need to be set.
+`QUAY_TOKEN` is a Quay OAuth Access Token. See https://docs.quay.io/api/ for documentation.
 
 Executing
 ```

--- a/images.go
+++ b/images.go
@@ -354,6 +354,12 @@ var Images = []Image{
 	},
 }
 
+func ImageName(organisation string, image Image) string {
+	parts := strings.Split(image.Name, "/")
+
+	return fmt.Sprintf("%v/%v", organisation, parts[len(parts)-1])
+}
+
 func RetaggedName(registry, organisation string, image Image) string {
 	parts := strings.Split(image.Name, "/")
 

--- a/images_test.go
+++ b/images_test.go
@@ -2,6 +2,41 @@ package main
 
 import "testing"
 
+func TestImageName(t *testing.T) {
+	organisation := "giantswarm"
+
+	tests := []struct {
+		image        Image
+		expectedName string
+	}{
+		{
+			image: Image{
+				Name: "quay.io/coreos/hyperkube",
+			},
+			expectedName: "giantswarm/hyperkube",
+		},
+		{
+			image: Image{
+				Name: "prom/prometheus",
+			},
+			expectedName: "giantswarm/prometheus",
+		},
+		{
+			image: Image{
+				Name: "golang",
+			},
+			expectedName: "giantswarm/golang",
+		},
+	}
+
+	for _, test := range tests {
+		returnedName := ImageName(organisation, test.image)
+		if returnedName != test.expectedName {
+			t.Fatalf("'%v' != '%v'", returnedName, test.expectedName)
+		}
+	}
+}
+
 func TestRetaggedName(t *testing.T) {
 	registry := "quay.io"
 	organisation := "giantswarm"


### PR DESCRIPTION
Using `docker pull` to check if an image exists in the registry is particularly slow. This changeset moves the image existence check to use the Quay.io API instead, which is considerably faster.

See https://quay.io/organization/giantswarm/application/J438SIDZN4Q2BC5RRROJ for retagger Quay.io application.
See https://circleci.com/gh/giantswarm/retagger/268 for an example of the build itself.