### PR TITLE
Fix source image sha on tagging command

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -101,9 +101,7 @@ func (r *Registry) Retag(image, sha, tag string) (string, error) {
 	retaggedName := RetaggedName(r.host, r.organisation, image)
 	retaggedNameWithTag := ImageWithTag(retaggedName, tag)
 
-	shaName := ShaName(image, tag)
-
-	retag := exec.Command("docker", "tag", shaName, retaggedNameWithTag)
+	retag := exec.Command("docker", "tag", sha, retaggedNameWithTag)
 	err := Run(retag)
 	if err != nil {
 		return "", microerror.Mask(err)


### PR DESCRIPTION
Aims to prevent this kind of errors:
```
Digest: sha256:104f434d47c8830be44560edc012c31114a104301cdb81bad6e8abc52a2304f9
Status: Downloaded newer image for grafana/grafana@sha256:104f434d47c8830be44560edc012c31114a104301cdb81bad6e8abc52a2304f9
Error parsing reference: "grafana/grafana@sha256:5.2.1" is not a valid repository/tag: invalid reference format
2018/06/29 11:13:24 could not retag image: exit status 1
Exited with code 1
```
Instead of using the precalculated source image tag, in the code it was being calculated again used tha `Tag` field instead of the `Sha` field. Tested locally.