### PR TITLE
Use v2 registry API

### DIFF
--- a/error.go
+++ b/error.go
@@ -17,3 +17,10 @@ var invalidStatusCodeError = microerror.New("invalid status code")
 func IsInvalidStatusCode(err error) bool {
 	return microerror.Cause(err) == invalidStatusCodeError
 }
+
+var invalidAuthenticateChallengeError = microerror.New("invalid authenticate challenge")
+
+// IsInvalidAuthenticateChallenge asserts invalidAuthenticateChallengeError.
+func IsInvalidAuthenticateChallenge(err error) bool {
+	return microerror.Cause(err) == invalidAuthenticateChallengeError
+}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ func main() {
 		Host:         os.Getenv("REGISTRY"),
 		Organisation: os.Getenv("REGISTRY_ORGANISATION"),
 		Password:     os.Getenv("REGISTRY_PASSWORD"),
-		Token:        os.Getenv("QUAY_TOKEN"),
 		Username:     os.Getenv("REGISTRY_USERNAME"),
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os/exec"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 )
@@ -27,6 +29,14 @@ type Registry struct {
 	password     string
 	token        string
 	username     string
+}
+
+type TagsListResponse struct {
+	Tags []string `json:"tags"`
+}
+
+type TokenRequestResponse struct {
+	Token string `json:"token"`
 }
 
 func NewRegistry(cfg *RegistryConfig) (*Registry, error) {
@@ -75,12 +85,18 @@ func (r *Registry) Login() error {
 }
 
 func (r *Registry) CheckImageTagExists(image, tag string) (bool, error) {
-	url := fmt.Sprintf("https://%s/api/v1/repository/%s/tag/%s/images", r.host, ImageName(r.organisation, image), tag)
+	url := fmt.Sprintf("https://%s/v2/%s/tags/list", r.host, ImageName(r.organisation, image))
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	token, err := r.getToken(req)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+	if token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
 
 	res, err := r.client.Do(req)
 	if err != nil {
@@ -90,7 +106,17 @@ func (r *Registry) CheckImageTagExists(image, tag string) (bool, error) {
 
 	switch res.StatusCode {
 	case http.StatusOK:
-		return true, nil
+		tagResponse := &TagsListResponse{}
+		err = json.NewDecoder(res.Body).Decode(tagResponse)
+		if err != nil {
+			return false, microerror.Mask(err)
+		}
+		for _, imageTag := range tagResponse.Tags {
+			if imageTag == tag {
+				return true, nil
+			}
+		}
+		return false, nil
 	default:
 		log.Printf("could not check retag status: %v", res.StatusCode)
 		return false, nil
@@ -107,4 +133,81 @@ func (r *Registry) Retag(image, sha, tag string) (string, error) {
 		return "", microerror.Mask(err)
 	}
 	return retaggedNameWithTag, nil
+}
+
+func (r *Registry) getToken(req *http.Request) (string, error) {
+	const authorizationHeaderKey = "Www-Authenticate"
+
+	res, err := r.client.Do(req)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer res.Body.Close()
+
+	authorizationHeaderValue := res.Header[authorizationHeaderKey]
+	if len(authorizationHeaderValue) == 0 {
+		// no need for authorization
+		return "", nil
+	}
+
+	authURL, err := getAuthURL(authorizationHeaderValue[0])
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	reqToken, err := http.NewRequest(http.MethodGet, authURL, nil)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	resToken, err := r.client.Do(reqToken)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer resToken.Body.Close()
+
+	tokenResponse := &TokenRequestResponse{}
+	err = json.NewDecoder(resToken.Body).Decode(tokenResponse)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return tokenResponse.Token, nil
+}
+
+func getAuthURL(authenticateChallenge string) (string, error) {
+	// www-authenticate headers have this form:
+	// Bearer realm="<realm>",service="<service>"[,scope="<scope>"]
+
+	authenticateChallenge = strings.Replace(authenticateChallenge, `"`, "", -1)
+
+	parts := strings.Fields(authenticateChallenge)
+	if len(parts) < 2 {
+		return "", microerror.Mask(invalidAuthenticateChallengeError)
+	}
+	items := strings.Split(parts[1], ",")
+	if len(items) < 2 {
+		return "", microerror.Mask(invalidAuthenticateChallengeError)
+	}
+	kv := strings.Split(items[0], "=")
+	if len(kv) < 2 {
+		return "", microerror.Mask(invalidAuthenticateChallengeError)
+	}
+	realm := kv[1]
+	kv = strings.Split(items[1], "=")
+	if len(kv) < 2 {
+		return "", microerror.Mask(invalidAuthenticateChallengeError)
+	}
+	service := kv[1]
+	var scope string
+	if len(items) == 3 {
+		kv = strings.Split(items[2], "=")
+		if len(kv) < 2 {
+			return "", microerror.Mask(invalidAuthenticateChallengeError)
+		}
+		scope = kv[1]
+	}
+
+	url := fmt.Sprintf("%s?service=%s&scope=%s", realm, service, scope)
+
+	return url, nil
 }

--- a/registry.go
+++ b/registry.go
@@ -101,9 +101,7 @@ func (r *Registry) Retag(image, sha, tag string) (string, error) {
 	retaggedName := RetaggedName(r.host, r.organisation, image)
 	retaggedNameWithTag := ImageWithTag(retaggedName, tag)
 
-	shaName := ShaName(image, tag)
-
-	retag := exec.Command("docker", "tag", shaName, retaggedNameWithTag)
+	retag := exec.Command("docker", "tag", sha, retaggedNameWithTag)
 	err := Run(retag)
 	if err != nil {
 		return "", microerror.Mask(err)

--- a/registry.go
+++ b/registry.go
@@ -17,7 +17,6 @@ type RegistryConfig struct {
 	Host         string
 	Organisation string
 	Password     string
-	Token        string
 	Username     string
 }
 
@@ -27,7 +26,6 @@ type Registry struct {
 	host         string
 	organisation string
 	password     string
-	token        string
 	username     string
 }
 
@@ -59,17 +57,12 @@ func NewRegistry(cfg *RegistryConfig) (*Registry, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Password must not be empty", cfg)
 	}
 
-	if cfg.Token == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Token must not be empty", cfg)
-	}
-
 	qr := &Registry{
 		client: cfg.Client,
 
 		host:         cfg.Host,
 		organisation: cfg.Organisation,
 		password:     cfg.Password,
-		token:        cfg.Token,
 		username:     cfg.Username,
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -138,8 +138,8 @@ func (r *Registry) getToken(req *http.Request) (string, error) {
 	defer res.Body.Close()
 
 	var authenticationHeaderValue []string
-	// the authentication header be found as www-authenticate, Www-Authenticate or
-	// WWW-Authenticate.
+	// the authentication header can be found as www-authenticate, Www-Authenticate
+	// or WWW-Authenticate.
 	for k, v := range res.Header {
 		if strings.ToLower(k) == authenticationHeaderKey {
 			authenticationHeaderValue = v

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func Test_GetAuthURL(t *testing.T) {
+	tcs := []struct {
+		challenge     string
+		expectedURL   string
+		expectedError bool
+		description   string
+	}{
+		{
+			description: "base case",
+			challenge:   `Bearer realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888",scope="repository:giantswarm/build-test:pull"`,
+			expectedURL: "https://dockerauth.aliyuncs.com/auth?service=registry.aliyuncs.com:cn-shanghai:26888&scope=repository:giantswarm/build-test:pull",
+		},
+		{
+			description: "missing scope is allowed",
+			challenge:   `Bearer realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888"`,
+			expectedURL: "https://dockerauth.aliyuncs.com/auth?service=registry.aliyuncs.com:cn-shanghai:26888&scope=",
+		},
+		{
+			description:   "missing Bearer causes error",
+			challenge:     `realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888"`,
+			expectedError: true,
+		},
+		{
+			description:   "missing service and scope causes error",
+			challenge:     `Bearer realm="https://dockerauth.aliyuncs.com/auth"`,
+			expectedError: true,
+		},
+		{
+			description:   "missing key value separator in realm causes error",
+			challenge:     `Bearer realm:"https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888",scope="repository:giantswarm/build-test:pull"`,
+			expectedError: true,
+		},
+		{
+			description:   "missing key value separator in service causes error",
+			challenge:     `Bearer realm="https://dockerauth.aliyuncs.com/auth",service:"registry.aliyuncs.com:cn-shanghai:26888",scope="repository:giantswarm/build-test:pull"`,
+			expectedError: true,
+		},
+		{
+			description:   "missing key value separator in scope causes error",
+			challenge:     `Bearer realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888",scope:"repository:giantswarm/build-test:pull"`,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			actual, err := getAuthURL(tc.challenge)
+			if tc.expectedError && err == nil {
+				t.Fatalf("expected error didn't happen")
+			}
+			if !tc.expectedError && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			if actual != tc.expectedURL {
+				t.Fatalf("unexpected URL, want %q, got %q", tc.expectedURL, actual)
+			}
+		})
+	}
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -10,37 +10,37 @@ func Test_GetAuthURL(t *testing.T) {
 		description   string
 	}{
 		{
-			description: "base case",
+			description: "case 0: base case",
 			challenge:   `Bearer realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888",scope="repository:giantswarm/build-test:pull"`,
 			expectedURL: "https://dockerauth.aliyuncs.com/auth?service=registry.aliyuncs.com:cn-shanghai:26888&scope=repository:giantswarm/build-test:pull",
 		},
 		{
-			description: "missing scope is allowed",
+			description: "case 1: missing scope is allowed",
 			challenge:   `Bearer realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888"`,
 			expectedURL: "https://dockerauth.aliyuncs.com/auth?service=registry.aliyuncs.com:cn-shanghai:26888&scope=",
 		},
 		{
-			description:   "missing Bearer causes error",
+			description:   "case 2: missing Bearer causes error",
 			challenge:     `realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888"`,
 			expectedError: true,
 		},
 		{
-			description:   "missing service and scope causes error",
+			description:   "case 3: missing service and scope causes error",
 			challenge:     `Bearer realm="https://dockerauth.aliyuncs.com/auth"`,
 			expectedError: true,
 		},
 		{
-			description:   "missing key value separator in realm causes error",
+			description:   "case 4: missing key value separator in realm causes error",
 			challenge:     `Bearer realm:"https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888",scope="repository:giantswarm/build-test:pull"`,
 			expectedError: true,
 		},
 		{
-			description:   "missing key value separator in service causes error",
+			description:   "case 5: missing key value separator in service causes error",
 			challenge:     `Bearer realm="https://dockerauth.aliyuncs.com/auth",service:"registry.aliyuncs.com:cn-shanghai:26888",scope="repository:giantswarm/build-test:pull"`,
 			expectedError: true,
 		},
 		{
-			description:   "missing key value separator in scope causes error",
+			description:   "case 6: missing key value separator in scope causes error",
 			challenge:     `Bearer realm="https://dockerauth.aliyuncs.com/auth",service="registry.aliyuncs.com:cn-shanghai:26888",scope:"repository:giantswarm/build-test:pull"`,
 			expectedError: true,
 		},


### PR DESCRIPTION
Uses registry v2 API for getting existing image tags on the target registry. Includes code for requesting a token according to https://docs.docker.com/registry/spec/auth/token/. Tested with Quay and aliyun.