### PR TITLE
Remove additional space in image tag

### DIFF
--- a/images.go
+++ b/images.go
@@ -361,7 +361,7 @@ var Images = []Image{
 		Tags: []Tag{
 			Tag{
 				Sha: "995bd3fee6899569d5d9ab77948f25d6bc2e9a95efa988de37c6b8c3095ac819",
-				Tag: "8cabd75bacbcdad7ac5d85efc3ca90c2fabf023b ",
+				Tag: "8cabd75bacbcdad7ac5d85efc3ca90c2fabf023b",
 			},
 		},
 	},


### PR DESCRIPTION
Typo, this will prevent:
```
Error parsing reference: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/docker-kubectl:8cabd75bacbcdad7ac5d85efc3ca90c2fabf023b " is not a valid repository/tag: invalid reference format
```