### PR TITLE
Persist images.yaml to CI workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
             giantswarm/yamllint \
             -d '{extends: default, rules: {line-length: {max: 200}, document-start: disable}}' \
             images.yaml
+
     - run:
         name: Install architect
         command: |
@@ -28,6 +29,7 @@ jobs:
         root: .
         paths:
         - ./retagger
+        - ./images.yaml
 
   retagQuay:
     environment:


### PR DESCRIPTION
`index.yaml` needs to be available in the workspace for subsequent job executions.