### PR TITLE
All overriding repository name

### DIFF
--- a/images.go
+++ b/images.go
@@ -11,9 +11,10 @@ import (
 
 // Image defines the data we process about a docker image.
 type Image struct {
-	Name    string `yaml:"name"`
-	Comment string `yaml:"comment,omitempty"`
-	Tags    []Tag  `yaml:"tags"`
+	Name         string `yaml:"name"`
+	Comment      string `yaml:"comment,omitempty"`
+	OverrideName string `yaml:"overrideName,omitempty"`
+	Tags         []Tag  `yaml:"tags"`
 }
 
 // Tag represents a specific version of a docker image, represented by a tag

--- a/images.go
+++ b/images.go
@@ -11,10 +11,10 @@ import (
 
 // Image defines the data we process about a docker image.
 type Image struct {
-	Name         string `yaml:"name"`
-	Comment      string `yaml:"comment,omitempty"`
-	OverrideName string `yaml:"overrideName,omitempty"`
-	Tags         []Tag  `yaml:"tags"`
+	Name             string `yaml:"name"`
+	Comment          string `yaml:"comment,omitempty"`
+	OverrideRepoName string `yaml:"overrideRepoName,omitempty"`
+	Tags             []Tag  `yaml:"tags"`
 }
 
 // Tag represents a specific version of a docker image, represented by a tag

--- a/main.go
+++ b/main.go
@@ -30,9 +30,9 @@ func main() {
 	for _, image := range Images {
 		for _, tag := range image.Tags {
 			imageName := image.Name
-			if image.OverrideName != "" {
-				log.Printf("Override Name specified. Using %s as mirrored image name", image.OverrideName)
-				imageName = image.OverrideName
+			if image.OverrideRepoName != "" {
+				log.Printf("Override Name specified. Using %s as mirrored image name", image.OverrideRepoName)
+				imageName = image.OverrideRepoName
 			}
 			log.Printf("managing: %v, %v, %v", imageName, tag.Sha, tag.Tag)
 

--- a/main.go
+++ b/main.go
@@ -29,14 +29,19 @@ func main() {
 
 	for _, image := range Images {
 		for _, tag := range image.Tags {
-			log.Printf("managing: %v, %v, %v", image.Name, tag.Sha, tag.Tag)
+			imageName := image.Name
+			if image.OverrideName != "" {
+				log.Printf("Override Name specified. Using %s as mirrored image name", image.OverrideName)
+				imageName = image.OverrideName
+			}
+			log.Printf("managing: %v, %v, %v", imageName, tag.Sha, tag.Tag)
 
-			ok, err := registry.CheckImageTagExists(image.Name, tag.Tag)
+			ok, err := registry.CheckImageTagExists(imageName, tag.Tag)
 			if ok {
 				log.Printf("retagged image already exists, skipping")
 				continue
 			} else if err != nil {
-				log.Fatalf("could not check image %q and tag %q: %v", image.Name, tag.Tag, err)
+				log.Fatalf("could not check image %q and tag %q: %v", imageName, tag.Tag, err)
 			} else {
 				log.Printf("retagged image does not exist")
 			}
@@ -49,7 +54,7 @@ func main() {
 				log.Fatalf("could not pull image: %v", err)
 			}
 
-			retaggedNameWithTag, err := registry.Retag(image.Name, shaName, tag.Tag)
+			retaggedNameWithTag, err := registry.Retag(imageName, shaName, tag.Tag)
 			if err != nil {
 				log.Fatalf("could not retag image: %v", err)
 			}


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

Regarding Retagger again: We have the case that we want to have `bitnami/redis` images in our repo. But we already have the `redis` repository mirroring.

that means `giantswarm/redis` already exists.

This PR add a new field `overrideName` to have the possibility to specify the destination repository name like this:

```yaml
- name: redis
  tags:
  - sha: 002a1870fa2ffd11dbd7438527a2c17f794f6962f5d3a4f048f848963ab954a8
    tag: 3.2.11-alpine
  - sha: 87275ecd3017cdacd3e93eaf07e26f4a91d7f4d7c311b2305fccb50ec3a1a8cd
    tag: 4.0.9
- name: bitnami/redis
  overrideName: bitnami-redis
  tags:
  - sha: 87275ecd3017cdacd3e93eaf07e26f4a91d7f4d7c311b2305fccb50ec3a1a8cd
    tag: 4.0.9```