### PR TITLE
Add new calico 3.6.1

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -185,18 +185,26 @@
   tags:
   - sha: 221e8056172f1acf5da4421eafa127a8947a4e8ecc9a216dda43057e66397598
     tag: v3.5.2
+  - sha: 3c029d6fbfb823acdd64d2802c0ba96029bb631a25ed464095544ed3b7e1c3a4
+    tag: v3.6.1
 - name: quay.io/calico/kube-controllers
   tags:
   - sha: 36f7eb17009e524263c7842f83ad1ac2c903e4b809dfc23a595a4a9cec90cffd
     tag: v3.5.2
+  - sha: 8945f0286e4c9fd16e131d8c8918532abee7c455df4525c216919ef384cfdab3
+    tag: v3.6.1
 - name: quay.io/calico/node
   tags:
   - sha: 153937ae38d6345478116c1e42e84ba1a88bfc210b02a6ec087cfb48dda13b12
     tag: v3.5.2
+  - sha: 703c48d59854cb566c6227cd68c30d8e59b61f5ea4b98cbbe81bdaf39b4bdc4a
+    tag: v3.6.1
 - name: quay.io/calico/typha
   tags:
   - sha: 1e0348cde23c2426454c40e11cea55d0c7d7de890ca2bb3ae105f35656d2e3c8
     tag: v3.5.2
+  - sha: 5640c3b77ca6ff324ff41aba7c9deb12c1cd13402ef877015a5f22d6e82361cf
+    tag: v3.6.1
 - name: quay.io/coreos/etcd
   tags:
   - sha: cb9cee3d9d49050e7682fde0a9b26d6948a0117b1b4367b8170fcaa3960a57b8


### PR DESCRIPTION
There is calico 3.6.1 now which is latest at the moment:
https://docs.projectcalico.org/v3.6/release-notes/