### PR TITLE
Add custom rebuild logic

### DIFF
--- a/error.go
+++ b/error.go
@@ -24,3 +24,10 @@ var invalidAuthenticateChallengeError = microerror.New("invalid authenticate cha
 func IsInvalidAuthenticateChallenge(err error) bool {
 	return microerror.Cause(err) == invalidAuthenticateChallengeError
 }
+
+var invalidTemplateError = microerror.New("invalidTemplateError")
+
+// IsInvalidTemplate asserts invalidTemplateError.
+func IsInvalidTemplate(err error) bool {
+	return microerror.Cause(err) == invalidTemplateError
+}

--- a/images.go
+++ b/images.go
@@ -24,6 +24,8 @@ type Tag struct {
 	Sha string `yaml:"sha"`
 	// Tag is the tag we apply to the pulled image.
 	Tag string `yaml:"tag"`
+	// DockerfileOptions - list of strings we add for Dockerfile to build custom image
+	DockerfileOptions []string `yaml:"dockerfileOoptions"`
 }
 
 // Images is the datastructure that will hold all image definitions.

--- a/images.yaml
+++ b/images.yaml
@@ -19,6 +19,8 @@
   tags:
   - sha: e83beb5e43f8513fa735e77ffc5859640baea30a882a11cc75c4c3244a737d3c
     tag: 1.5.0
+    dockerfileOptions:
+      - EXPOSE 1053
 - name: dduportal/bats
   tags:
   - sha: b2d533b27109f7c9ea1e270e23f212c47906346f9cffaa4da6da48ed9d8031da

--- a/main.go
+++ b/main.go
@@ -59,10 +59,24 @@ func main() {
 				log.Fatalf("could not retag image: %v", err)
 			}
 
-			log.Printf("pushing image")
+			log.Printf("pushing retagged image")
 			push := exec.Command("docker", "push", retaggedNameWithTag)
 			if err := Run(push); err != nil {
 				log.Fatalf("could not push image: %v", err)
+			}
+
+			if len(tag.DockerfileOptions) != 0 {
+				rebuildedImageTag, err := registry.Rebuild(imageName, tag.Tag, tag.DockerfileOptions)
+				if err != nil {
+					log.Fatalf("could not rebuild image: %v", err)
+				}
+
+				log.Printf("pushing rebuilded image")
+				push := exec.Command("docker", "push", rebuildedImageTag)
+				if err := Run(push); err != nil {
+					log.Fatalf("could not push image: %v", err)
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
Add logic for custom images rebuilds.
---
```
- name: coredns/coredns                                                         
  tags:                                                                         
  - sha: e83beb5e43f8513fa735e77ffc5859640baea30a882a11cc75c4c3244a737d3c       
    tag: 1.5.0                                                                  
    dockerfileOptions:                                                          
      - EXPOSE 1053
```

This will retag `coredns/coredns:1.5.0` into `quay.io/giantswarm/coredns:1.5.0` with th and additionally rebuild `quay.io/giantswarm/coredns:1.5.0-giantswarm` from Dockerfile
```
FROM coredns/coredns;1.5.0
EXPOSE 1053
```