### PR TITLE
Fix registry login

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,11 @@ func main() {
 		log.Fatalf("could not create registry %v", err)
 	}
 
+	err = registry.Login()
+	if err != nil {
+		log.Fatalf("could not login to registry %v", err)
+	}
+
 	for _, image := range Images {
 		for _, tag := range image.Tags {
 			imageName := image.Name


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6046

Fix a regression introduced [recently](https://github.com/giantswarm/retagger/commit/03df444882e612cac34edb3bc23eef302248af24#diff-7ddfb3e035b42cd70649cc33393fe32cL25) were registry login was removed. This results in permission denied when trying to push new images.

https://circleci.com/gh/giantswarm/retagger/902
https://circleci.com/gh/giantswarm/retagger/901
```
2019/05/21 10:32:38 pushing retagged image
The push refers to a repository [quay.io/giantswarm/node-exporter]
unauthorized: access to the requested resource is not authorized
2019/05/21 10:32:39 could not push image: exit status 1
Exited with code 1
```