### PR TITLE
Add retagging of kindest/node images

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -176,6 +176,13 @@
     tag: v1.13.4
   - sha: b1f8e7b784cec96304ca086ece96679de7473786d7c298b285cb3d7dcad2d582
     tag: v1.14.1
+- name: kindest/node
+  overrideRepoName: kind-node
+  tags:
+  - sha: 9e07014fb48c746deb98ec8aafd58c3918622eca6063e643c6e6d86c86e170b4
+    tag: v1.13.6
+  - sha: 33539d830a6cf20e3e0a75d0c46a4e94730d78c7375435e6b49833d81448c319
+    tag: v1.14.2
 - name: koalaman/shellcheck-alpine
   tags:
   - sha: 7d4d712a2686da99d37580b4e2f45eb658b74e4b01caf67c1099adc294b96b52


### PR DESCRIPTION
This PR declares retagging of kindest/node images for use in e2e testing.
Repositories have been created:
- https://quay.io/repository/giantswarm/kind-node
- https://cr.console.aliyun.com/repository/cn-shanghai/giantswarm/kind-node/details

For more info see https://github.com/giantswarm/giantswarm/issues/4606#issuecomment-499127288