### PR TITLE
add giantswarm user to the node-exporter image

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -312,6 +312,11 @@
     tag: v0.17.0
   - sha: b2dd31b0d23fda63588674e40fd8d05010d07c5d4ac37163fc596ba9065ce38d
     tag: v0.18.0
+    customImages:
+    - tagSuffix: giantswarm
+      dockerfileOptions:
+      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
+      - USER giantswarm
 - name: redis
   tags:
   - sha: 002a1870fa2ffd11dbd7438527a2c17f794f6962f5d3a4f048f848963ab954a8


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6178.

Required for https://github.com/giantswarm/kubernetes-node-exporter/pull/44.