### PR TITLE
Bump CoreDNS to 1.5.1

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -24,8 +24,8 @@
     tag: 0.12
 - name: coredns/coredns
   tags:
-  - sha: e83beb5e43f8513fa735e77ffc5859640baea30a882a11cc75c4c3244a737d3c
-    tag: 1.5.0
+  - sha: 451817637035535ae1fc8639753b453fa4b781d0dea557d5da5cb3c131e62ef5
+    tag: 1.5.1
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:


### PR DESCRIPTION

Bump CoreDNS to 1.5.1

Release notes https://coredns.io/2019/06/26/coredns-1.5.1-release/