### PR TITLE
hyperkube-1.15.4

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -189,6 +189,8 @@
     tag: v1.14.6
   - sha: 931494f8920a3eb4e6fb9c558083e088bf089a66ade026ccfab986e42a7aa3d8
     tag: v1.15.3
+  - sha: a58aec353b510226bd5afe3efcb611784e9abc7de38c6efb8b10bf08643af9af
+    tag: v1.15.4
 - name: k8s.gcr.io/metrics-server-amd64
   tags:
   - sha: 4ca116565ff6a46e582bada50ba3550f95b368db1d2415829241a565a6c38e2a


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6431

Should I remove any of the older `hyperkube` images in this PR?