### PR TITLE
Schedule retagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,27 +101,27 @@ jobs:
           name: Execute retagger
           command: ./retagger -r ${REGISTRY} -o ${REGISTRY_ORGANISATION} -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD}
 
-build_and_retag:  &build_e2e:
-    jobs:
-      - build
-      - e2eQuay:
-          filters:
-            branches:
-              ignore: master
-          requires:
-            - build
-      - retagQuay:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-      - retagAliyun:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
+build_and_retag:  &build_and_retag
+  jobs:
+    - build
+    - e2eQuay:
+        filters:
+          branches:
+            ignore: master
+        requires:
+          - build
+    - retagQuay:
+        filters:
+          branches:
+            only: master
+        requires:
+          - build
+    - retagAliyun:
+        filters:
+          branches:
+            only: master
+        requires:
+          - build
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,10 +101,7 @@ jobs:
           name: Execute retagger
           command: ./retagger -r ${REGISTRY} -o ${REGISTRY_ORGANISATION} -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD}
 
-
-workflows:
-  version: 2
-  build_e2e:
+build_and_retag:  &build_e2e:
     jobs:
       - build
       - e2eQuay:
@@ -125,3 +122,18 @@ workflows:
               only: master
           requires:
             - build
+
+workflows:
+  version: 2
+  build_retag: 
+    <<: *build_and_retag
+
+  # Runs nightly at 21:30 UTC (22:30 Berlin)
+  build_retag_nightly:
+    triggers:
+      - schedule:
+          cron: "30 21 * * *"
+          filters:
+            branches:
+              only: master
+    <<: *build_and_retag


### PR DESCRIPTION
Runs `retagger`'s CI workflow every night at 21:30 UTC (22:30 Berlin time). 

I like this time because:
- most k8s releases happen between 1000 and 1300 PST which is 1800-2100 UTC
- this is outside normal Europe working hours so limits distractions
- it is early enough in the night to let dependent automated jobs (even long-running ones) finish before start of business

Towards https://github.com/giantswarm/giantswarm/issues/5968