### PR TITLE
Add patterns for hyperkube v1.17.x, v1.18.x, and v1.18.x release candidates

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -219,7 +219,8 @@
     tag: v1.16.3
 - name: k8s.gcr.io/hyperkube
   patterns:
-  - pattern: '\A(v1.17.[0-9]+)(-rc.[0-9.]+)*\z'  # Match any v1.17.x or v1.17.x-rc.x
+  - pattern: '\A(v1.17.[0-9]+)\z'                # Match any v1.17.x
+  - pattern: '\A(v1.18.[0-9]+)(-rc.[0-9.]+)*\z'  # Match any v1.18.x or v1.18.x-rc.x
   tags:
   - sha: 94adb47a41838bee7deee7e09d07a7093bdba517d980c66115cc2eeb675090be
     tag: v1.14.6

--- a/images.yaml
+++ b/images.yaml
@@ -218,6 +218,8 @@
   - sha: 6b887823b1fd2789aa926f7bd3d5efa5c3bec5a194f72da121c292d95204a3b7
     tag: v1.16.3
 - name: k8s.gcr.io/hyperkube
+  patterns:
+  - pattern: '\A(v1.17.[0-9]+)(-rc.[0-9.]+)*\z'  # Match any v1.17.x or v1.17.x-rc.x
   tags:
   - sha: 94adb47a41838bee7deee7e09d07a7093bdba517d980c66115cc2eeb675090be
     tag: v1.14.6


### PR DESCRIPTION
Adding these patterns to follow new 1.17 and 1.18 releases.

Adds patterns for k8s (hyperkube):
- v1.17.x
- v1.18.x _or_ v1.18.x-rc.x

Dry-run results:
This will retag only v1.17.0 immediately

Towards https://github.com/giantswarm/giantswarm/issues/5968