### PR TITLE
Exclude v1.x.0 as these don't exist on gcr.io

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -219,8 +219,8 @@
     tag: v1.16.3
 - name: k8s.gcr.io/hyperkube
   patterns:
-  - pattern: '\A(v1.17.[0-9]+)\z'                # Match any v1.17.x
-  - pattern: '\A(v1.18.[0-9]+)(-rc.[0-9.]+)*\z'  # Match any v1.18.x or v1.18.x-rc.x
+  - pattern: '\A(v1.17.[1-9][0-9]*)\z'                # Match any v1.17.x
+  - pattern: '\A(v1.18.[1-9][0-9]*)(-rc.[0-9.]+)*\z'  # Match any v1.18.x or v1.18.x-rc.x
   tags:
   - sha: 94adb47a41838bee7deee7e09d07a7093bdba517d980c66115cc2eeb675090be
     tag: v1.14.6


### PR DESCRIPTION
K8s images v1.x.0 don't exist in the google container registry, so limit the pattern to .1 and later
