### PR TITLE
Use ManifestV2Digest when getting SHA from external registry

### DIFF
--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -57,7 +57,7 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 		_, exists := existingTagMap[match]
 		if !exists {
 			// Tag is new - get SHA and tag it.
-			newDigest, err := externalRegistry.ManifestDigest(job.Source.FullImageName, match)
+			newDigest, err := externalRegistry.ManifestV2Digest(job.Source.FullImageName, match)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}


### PR DESCRIPTION
SHAs fetched from the "local" registry (quay or Aliyun) use the V2 schema, but the fetch for "remote" registries was using the V1 schema. In many cases, these SHAs are the same, but this is not guaranteed. Since the pull behavior uses the V2 schema, this breaks if a V1 SHA is used to define the job.
