### PR TITLE
Bump Kong image tag

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -271,6 +271,8 @@
     tag: 1.3
   - sha: 027f0a48dd57f5d8ac06d6d5768807caaa03a2e674c8f5d2abb6e41faaea05ae
     tag: 1.4.2
+  - sha: a88c35cb8e7807966b6aaf1b41da3809b4b2c86ae50f7d036f90cb2aa747133a
+    tag: 1.4.3
 - name: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
   tags:
   - sha: 018a8cf2c6738d296abbea6bbfa25e2eb46ebd48fa2d6886fc15fcaf015b4dd3


### PR DESCRIPTION
1.4.3 contains security fixes



_Retagger_

https://github.com/giantswarm/giantswarm/blob/master/ops-recipes/container-registry.md

---