### PR TITLE
add kube-state-metrics v1.9.2

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -369,12 +369,8 @@
     tag: v0.11.0-amd64
 - name: quay.io/coreos/kube-state-metrics
   tags:
-  - sha: 99a3e3297e281fec09fe850d6d4bccf4d9fd58ff62a5b37764d8a8bd1e79bd14
-    tag: v1.7.2
-  - sha: e9ec63c8866fe8670f35abcc14f1388553b2c329ec8bb78b04ce795cd04cb4f5
-    tag: v1.8.0
-  - sha: 56e2ea990a95359a37b4510e3bb3907224a9ec86efd7759c4ce3372d4f58f7cf
-    tag: v1.9.0
+  - sha: 99e18bb3ca7344cb8ece2b5ced2599d561d2de2306531366e8198364d17b0f22
+    tag: v1.9.2
 - name: quay.io/coreos/prometheus-operator
   tags:
   - sha: 97697df680ea4c7e70c4cb4af5bdc44f7a70b25be7afde70bd921a658e4c62ec


### PR DESCRIPTION
As preparation for upgrade of our app this PR add retagging for kube-state-metrics v1.9.2