### PR TITLE
add addon-resizer 1.8.7

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -205,8 +205,8 @@
     tag: 0.1
 - name: k8s.gcr.io/addon-resizer
   tags:
-  - sha: a31822f30e947885d038812f4a5a5675e72f92c06cef17b1989c80426aa89012
-    tag: "1.8.4"
+  - sha: 30b3b12e471c534949e12d2da958fdf33848d153f2a0a88565bdef7ca999b5ad
+    tag: "1.8.7"
 - name: k8s.gcr.io/cluster-autoscaler
   tags:
   - sha: 7ff5a60304b344f2f29c804c7253632bbc818794f6932236a56db107a6a8f5af


### PR DESCRIPTION
Upgrading kube-state-metrics to 1.9.2 and noticed that there's newer addon-resizer too (used as sidecar in kube-state-metrics-app). addon-resizer 1.8.7 switches from extensions to to apps/v1 Deployments API making it k8s 1.16 compatible https://github.com/kubernetes/autoscaler/commits/addon-resizer-release-1.8/addon-resizer