### PR TITLE
Try registry backoff

### DIFF
--- a/images-e2e.yaml
+++ b/images-e2e.yaml
@@ -11,4 +11,4 @@
             - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
             - USER giantswarm
   patterns:
-    - pattern: '<= 2.6'  # Match 2.5 or 2.6 - only 2.6 exists
+    - pattern: '2.5 - 2.6'  # Match 2.5 or 2.6 - only 2.6 exists

--- a/images-e2e.yaml
+++ b/images-e2e.yaml
@@ -11,4 +11,4 @@
             - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
             - USER giantswarm
   patterns:
-    - pattern: '>= 2.5 <= 2.6'  # Match 2.5 or 2.6 - only 2.6 exists
+    - pattern: '<= 2.6'  # Match 2.5 or 2.6 - only 2.6 exists

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -53,7 +53,7 @@ type Registry struct {
 
 type backoffTransport struct {
 	Transport http.RoundTripper
-	logger micrologger.Logger
+	logger    micrologger.Logger
 }
 
 func (t *backoffTransport) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -61,7 +61,7 @@ func (t *backoffTransport) RoundTrip(request *http.Request) (*http.Response, err
 	var resp *http.Response
 
 	{
-		o := func () error {
+		o := func() error {
 			var respErr error
 			resp, respErr = t.Transport.RoundTrip(request)
 			// Internal error, return nil to prevent retry

--- a/pkg/retagger/error.go
+++ b/pkg/retagger/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var rateLimitedError = &microerror.Error{
+	Kind: "rateLimitedError",
+}
+
+// IsRateLimited asserts rateLimitedError.
+func IsRateLimited(err error) bool {
+	return microerror.Cause(err) == rateLimitedError
+}

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -84,7 +84,7 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 				logger: r.logger,
 			},
 		},
-		Logf: dockerRegistry.Quiet,
+		Logf: dockerRegistry.Log,
 		URL:  fmt.Sprintf("https://%s", job.Source.RepoPath),
 	}
 

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -81,6 +81,8 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 				},
 			},
 		},
+		Logf: dockerRegistry.Quiet,
+		URL:  fmt.Sprintf("https://%s", job.Source.RepoPath),
 	}
 
 	// Find tags which match the pattern.

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -25,7 +25,7 @@ type PatternJob struct {
 
 // Compile expands a PatternJob into one or multiple SingleJobs using the given Retagger instance.
 func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
-	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image % v / %v using pattern %v, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.Options))
+	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v / %v using pattern %v, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.Options))
 
 	// Create a reference to the external registry.
 	url := fmt.Sprintf("https://%s", job.Source.RepoPath)

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -70,7 +70,7 @@ func (t *backoffTransport) RoundTrip(request *http.Request) (*http.Response, err
 
 // Compile expands a PatternJob into one or multiple SingleJobs using the given Retagger instance.
 func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
-	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v using pattern %v, with options %#v", job.Source.Image, job.SourcePattern, job.Options))
+	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v using pattern %v / %v, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.Options))
 
 	// Create a reference to the external registry.
 	externalRegistry := &dockerRegistry.Registry{

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -70,7 +70,7 @@ func (t *backoffTransport) RoundTrip(request *http.Request) (*http.Response, err
 
 // Compile expands a PatternJob into one or multiple SingleJobs using the given Retagger instance.
 func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
-	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v using pattern %v / %v, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.Options))
+	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image % v / %v using pattern %v, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.Options))
 
 	// Create a reference to the external registry.
 	externalRegistry := &dockerRegistry.Registry{
@@ -162,6 +162,7 @@ func (job *PatternJob) getExternalTagMatches(r *dockerRegistry.Registry, image s
 	// Find tags matching our configured pattern.
 	var matches []string
 	for _, t := range externalRegistryTags {
+		job.logger.Log("level", "debug", "message", fmt.Sprintf("External Tag %s ", t))
 		v, err := semver.NewVersion(t)
 		if err != nil { // We do not care if the version is not semver.
 			continue

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -33,7 +33,7 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 	externalRegistry := &dockerRegistry.Registry{
 		Client: &http.Client{Transport: transport},
 		URL:    url,
-		Logf:   dockerRegistry.Quiet,
+		Logf:   dockerRegistry.Quiet, // Ignore logs
 	}
 
 	// Find tags which match the pattern.

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -31,9 +31,9 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 	url := fmt.Sprintf("https://%s", job.Source.RepoPath)
 	transport := wrapTransport(http.DefaultTransport, url, job.logger)
 	externalRegistry := &dockerRegistry.Registry{
-		Client: &http.Client{ Transport: transport },
-		URL: url,
-		Logf: dockerRegistry.Quiet,
+		Client: &http.Client{Transport: transport},
+		URL:    url,
+		Logf:   dockerRegistry.Quiet,
 	}
 
 	// Find tags which match the pattern.

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -77,7 +77,7 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 			Transport: &dockerRegistry.ErrorTransport{
 				Transport: &backoffTransport{
 					Transport: http.DefaultTransport,
-					logger: r.logger,
+					logger:    r.logger,
 				},
 			},
 		},

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -2,7 +2,6 @@ package retagger
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
@@ -76,12 +75,8 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 	externalRegistry := &dockerRegistry.Registry{
 		Client: &http.Client{
 			Transport: &backoffTransport{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
-				},
-				logger: r.logger,
+				Transport: http.DefaultTransport,
+				logger:    r.logger,
 			},
 		},
 		Logf: dockerRegistry.Log,

--- a/pkg/retagger/transport.go
+++ b/pkg/retagger/transport.go
@@ -69,4 +69,3 @@ func wrapTransport(transport http.RoundTripper, url string, logger micrologger.L
 	}
 	return transport
 }
-

--- a/pkg/retagger/transport.go
+++ b/pkg/retagger/transport.go
@@ -1,0 +1,72 @@
+package retagger
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/nokia/docker-registry-client/registry"
+)
+
+type backoffTransport struct {
+	Transport http.RoundTripper
+	logger    micrologger.Logger
+}
+
+func (t *backoffTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	var err error
+	var resp *http.Response
+
+	{
+		o := func() error {
+			var respErr error
+			resp, respErr = t.Transport.RoundTrip(request)
+			// Internal error, return nil to prevent retry
+			if respErr != nil {
+				err = respErr
+				return nil
+			}
+			// Rate limited
+			if resp.StatusCode == 429 {
+				return microerror.New("rate limited")
+			}
+			// Not rate limited, return nil to prevent retry
+			return nil
+		}
+		b := backoff.NewExponential(time.Minute, 10*time.Second)
+		n := backoff.NewNotifier(t.logger, context.Background())
+		backoffErr := backoff.RetryNotify(o, b, n)
+		// Report errors unrelated to rate limiting first
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		// Rate limited and backoff wasn't sufficient
+		if backoffErr != nil {
+			return nil, microerror.Mask(backoffErr)
+		}
+	}
+
+	return resp, nil
+}
+
+func wrapTransport(transport http.RoundTripper, url string, logger micrologger.Logger) http.RoundTripper {
+	transport = &registry.TokenTransport{
+		Transport: transport,
+	}
+	transport = &registry.BasicTransport{
+		Transport: transport,
+		URL:       url,
+	}
+	transport = &backoffTransport{
+		Transport: transport,
+		logger:    logger,
+	}
+	transport = &registry.ErrorTransport{
+		Transport: transport,
+	}
+	return transport
+}
+

--- a/pkg/retagger/transport.go
+++ b/pkg/retagger/transport.go
@@ -11,47 +11,56 @@ import (
 	"github.com/nokia/docker-registry-client/registry"
 )
 
+// backoffTransport retries requests on 429 responses
 type backoffTransport struct {
 	Transport http.RoundTripper
 	logger    micrologger.Logger
 }
 
+// RoundTrip implements the RoundTripper interface for backoffTransport
+// It acts as a sort of middleware, round-tripping using the wrapped transport,
+// retrying on 429 error using exponential backoff and passing through on success
+// or any other error or if the backoff retry time limit is reached.
 func (t *backoffTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	var err error
+	var innerErr error
 	var resp *http.Response
 
-	{
-		o := func() error {
-			var respErr error
-			resp, respErr = t.Transport.RoundTrip(request)
-			// Internal error, return nil to prevent retry
-			if respErr != nil {
-				err = respErr
-				return nil
-			}
-			// Rate limited
-			if resp.StatusCode == 429 {
-				return microerror.New("rate limited")
-			}
-			// Not rate limited, return nil to prevent retry
+	o := func() error {
+		var respErr error
+		resp, respErr = t.Transport.RoundTrip(request)
+		// Internal error, return nil to prevent retry
+		if respErr != nil {
+			innerErr = respErr
 			return nil
 		}
-		b := backoff.NewExponential(time.Minute, 10*time.Second)
-		n := backoff.NewNotifier(t.logger, context.Background())
-		backoffErr := backoff.RetryNotify(o, b, n)
-		// Report errors unrelated to rate limiting first
-		if err != nil {
-			return nil, microerror.Mask(err)
+		// Rate limited
+		if resp.StatusCode == 429 {
+			return rateLimitedError
 		}
-		// Rate limited and backoff wasn't sufficient
-		if backoffErr != nil {
-			return nil, microerror.Mask(backoffErr)
-		}
+		// Not rate limited, return nil to prevent retry
+		return nil
+	}
+	b := backoff.NewExponential(time.Minute, 10*time.Second)
+	n := backoff.NewNotifier(t.logger, context.Background())
+	backoffErr := backoff.RetryNotify(o, b, n)
+
+	// Report errors unrelated to rate limiting first
+	if innerErr != nil {
+		return nil, microerror.Mask(innerErr)
+	}
+	// Rate limited and backoff time limit was reached
+	if backoffErr != nil {
+		return nil, microerror.Mask(backoffErr)
 	}
 
 	return resp, nil
 }
 
+// wrapTransport wraps the given transport with several custom RoundTrippers that handle
+// - Token-based authentication (registry.TokenTransport)
+// - HTTP basic authentication (registry.BasicTransport)
+// - Rate limiting (backoffTransport)
+// - Errors (registry.ErrorTransport)
 func wrapTransport(transport http.RoundTripper, url string, logger micrologger.Logger) http.RoundTripper {
 	transport = &registry.TokenTransport{
 		Transport: transport,


### PR DESCRIPTION
To avoid registry rate limiting, this creates a Registry manually instead of using registry.New and passes in an http.Client with a custom transport wrapper which applies exponential backoff in the case of a 429 response.