### PR TITLE
Catch quay repo not exist for tags

### DIFF
--- a/pkg/registry/registry_quay.go
+++ b/pkg/registry/registry_quay.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	nurl "net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/giantswarm/backoff"
@@ -93,6 +94,11 @@ func (r *Registry) GetQuayTagsWithDetails(image string) (tags []QuayTag, err err
 			if err != nil {
 				if IsNoMorePages(err) {
 					tags = append(tags, response.Tags...)
+					return nil
+				}
+				if strings.Contains(err.Error(), "Requires authentication") {
+					msg := fmt.Sprintf("unable to list tags for %s: HTTP 401 - Requires authentication. If the repository does not exist, retagger will try to create it. If the repository exists, check that the user has access to it", image)
+					r.logger.Log("level", "warn", "message", msg)
 					return nil
 				}
 

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -29,26 +29,11 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 
 	// Create a reference to the external registry.
 	url := fmt.Sprintf("https://%s", job.Source.RepoPath)
-	var externalRegistry *dockerRegistry.Registry
-	var err error
-	old := false
-	if old {
-		o := dockerRegistry.Options{
-			Logf:          dockerRegistry.Quiet,
-			DoInitialPing: false,
-		}
-		externalRegistry, err = dockerRegistry.NewCustom(url, o)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	} else {
-		transport := wrapTransport(http.DefaultTransport, url, job.logger)
-		externalRegistry = &dockerRegistry.Registry{
-			Client: &http.Client{Transport: transport},
-			URL:    url,
-			//Logf:   dockerRegistry.Quiet, // Ignore logs
-			Logf: dockerRegistry.Log,
-		}
+	transport := wrapTransport(http.DefaultTransport, url, job.logger)
+	externalRegistry := &dockerRegistry.Registry{
+		Client: &http.Client{Transport: transport},
+		URL:    url,
+		Logf:   dockerRegistry.Quiet, // Ignore logs
 	}
 
 	// Find tags which match the pattern.


### PR DESCRIPTION
If a Quay repo doesn't exist for a tags query, it returns a 401 saying it needs authentication. Unfortunately, a nice error structure is not preserved by underlying functions so we have to just match a string. If the repo doesn't exist, we know retagger will try to create it, but print a warning just in case the user actually doesn't have access rights for the repo.

Towards https://github.com/giantswarm/giantswarm/issues/8839