### PR TITLE
Retry on trailer EOF error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192
-	github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5
+	github.com/giantswarm/microerror v0.1.0
 	github.com/giantswarm/micrologger v0.0.0-20191014091141-d866337f7393
 	github.com/go-kit/kit v0.6.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192 h1:jguq2nu1gbvP
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192/go.mod h1:kjItv/iHgl/xsprYgbnCOme1pVTiiiaZeR2ybsN4ab0=
 github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5 h1:ZjMQRWyxNkGlFP8yOf+G86XH7DugnigsBpzie1R/nxM=
 github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5/go.mod h1://Lo9dKJ8P2TBciuky5fDHEItccyvZOWE+B/0JiJT8A=
+github.com/giantswarm/microerror v0.1.0 h1:kQ38fLkFk3tz08Hltu6G52bTKW4vxCvp4sW5iQ7K4oI=
+github.com/giantswarm/microerror v0.1.0/go.mod h1://Lo9dKJ8P2TBciuky5fDHEItccyvZOWE+B/0JiJT8A=
 github.com/giantswarm/micrologger v0.0.0-20191014091141-d866337f7393 h1:iwdDYJLDPkWo71fPO57Q40qNsjpXlH/KNznqgByo0xA=
 github.com/giantswarm/micrologger v0.0.0-20191014091141-d866337f7393/go.mod h1:2O9GG1AfKI8px8oseWx+TTD6A6aEdUo16ZjAKv2wOVk=
 github.com/go-kit/kit v0.6.0 h1:wTifptAGIyIuir4bRyN4h7+kAa2a4eepLYVmRe5qqQ8=

--- a/pkg/retagger/error.go
+++ b/pkg/retagger/error.go
@@ -19,3 +19,11 @@ var rateLimitedError = &microerror.Error{
 func IsRateLimited(err error) bool {
 	return microerror.Cause(err) == rateLimitedError
 }
+
+// Copied from net/http/transport.go:911
+var trailerEOFErrorString = "http: unexpected EOF reading trailer"
+
+// IsTrailerEOF asserts error string matches trailerEOFErrorString.
+func IsTrailerEOF(err error) bool {
+	return microerror.Cause(err).Error() == trailerEOFErrorString
+}


### PR DESCRIPTION
Solves https://github.com/giantswarm/giantswarm/issues/8841

If a chunked response ends unexpectedly (maybe due to a server failure, network issues, or silent rate limiting), the Go http transport will attempt to parse trailers (like headers but at the end of a response), find zero bytes remaining instead of `\r\n` (indicates the final chunk) and return a new error with string `"http: unexpected EOF reading trailer"`. This error happens intermittently, maybe 1% of the time during a full retagger execution. My solution is to wrap the registry tags function call with a backoff retry just like for the rate limiting issue. I also cleaned up the rate limiting backoff using `backoff.Permanent` which I just discovered.