### PR TITLE
Remove docker-kubectl

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -309,12 +309,6 @@
 - name: quay.io/fluentd_elasticsearch/fluentd
   patterns:
   - pattern: '>= v2.9.0'
-- name: quay.io/giantswarm/docker-kubectl
-  tags:
-  - sha: 995bd3fee6899569d5d9ab77948f25d6bc2e9a95efa988de37c6b8c3095ac819
-    tag: 8cabd75bacbcdad7ac5d85efc3ca90c2fabf023b
-  - sha: 93404a39c4b83568aef2971504fecc39efc6a9b949fd84cc9814742a76033ed3
-    tag: f5cae44c480bd797dc770dd5f62d40b74063c0d7
 - name: quay.io/giantswarm/docker-strongswan
   tags:
   - sha: 0deee46507d8d9c354b9e924f969dfb370083539a7130531b575e05a09603a31


### PR DESCRIPTION
As of https://github.com/giantswarm/docker-kubectl/pull/15 docker-kubectl is published not only to quay but also to aliyun via circleci build so there's no need for retagging image. It's not only redundant but it was messing up, retagging old version, making quay and aliyun latest tags inconsistent, e.g. here's docker image history between what used to be latest docker-kubectl image on aliyun:

```
$ docker history 914910eb87c6
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
914910eb87c6        2 weeks ago         /bin/sh -c #(nop)  CMD ["/bin/sh" "-c" "./ge…   0B                  
<missing>           2 weeks ago         /bin/sh -c #(nop)  USER [1000]                  0B                  
<missing>           2 weeks ago         /bin/sh -c chmod +x generate_certs.sh && cho…   2.04kB              
<missing>           2 weeks ago         /bin/sh -c #(nop) COPY file:acc33b265c6b1fc4…   2.04kB              
<missing>           2 weeks ago         /bin/sh -c chown 1000:1000 .                    0B                  
<missing>           2 weeks ago         /bin/sh -c #(nop) WORKDIR /workspace            0B                  
<missing>           2 weeks ago         /bin/sh -c curl https://storage.googleapis.c…   46.7MB              
<missing>           2 weeks ago         /bin/sh -c curl -L https://github.com/square…   6.19MB              
<missing>           3 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
<missing>           3 months ago        /bin/sh -c #(nop) ADD file:298f828afc880ccde…   194MB               
<missing>           4 months ago        /bin/sh -c #(nop)  ENV DISTTAG=f31-updates-c…   0B                  
<missing>           13 months ago       /bin/sh -c #(nop)  LABEL maintainer=Clement …   0B                 
```

and latest from quay:

```
$ docker history 193560431488
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
193560431488        3 weeks ago         /bin/sh -c #(nop)  ENTRYPOINT ["kubectl"]       0B                  
<missing>           3 weeks ago         /bin/sh -c apk add --no-cache ca-certificate…   49.6MB              
<missing>           4 weeks ago         /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop) ADD file:e69d441d729412d24…   5.59MB              
```

I've rerun the docker-kubectl last circle build, and now both are the same.

I've noticed the inconsistency while testing legacy AWS 9.1.1 release, with improved cluster-issuer subchart of cert-manager-app (1.0.5), https://github.com/giantswarm/cert-manager-app/pull/13, which is now pulling docker-kubectl image in China TCs from aliyun (with configured global.image.registry in default app catalog for the installation), and from quay by default.