### PR TITLE
allow alpine non-root user to sudo

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -4,7 +4,11 @@
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:
-      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm && apk add --no-cache sudo && addgroup giantswarm wheel && echo "%wheel ALL=(ALL)  NOPASSWD: ALL" >> /etc/sudoers
+      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
+      - USER giantswarm
+    - tagSuffix: giantswarm-sysctl
+      dockerfileOptions:
+      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm && apk add --no-cache sudo && echo "giantswarm  ALL = NOPASSWD: /sbin/sysctl" >> /etc/sudoers
       - USER giantswarm
 - name: amazon/opendistro-for-elasticsearch
   patterns:

--- a/images.yaml
+++ b/images.yaml
@@ -9,7 +9,7 @@
     - tagSuffix: giantswarm-sysctl
       dockerfileOptions:
       - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
-      - RUN apk add --no-cache sudo && echo "giantswarm  ALL = NOPASSWD: /sbin/sysctl" >> /etc/sudoers
+      - 'RUN apk add --no-cache sudo && echo "giantswarm  ALL = NOPASSWD: /sbin/sysctl" >> /etc/sudoers'
       - USER giantswarm
 - name: amazon/opendistro-for-elasticsearch
   patterns:

--- a/images.yaml
+++ b/images.yaml
@@ -4,7 +4,7 @@
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:
-      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
+      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm && apk add --no-cache sudo && addgroup giantswarm wheel && echo "%wheel ALL=(ALL)  NOPASSWD: ALL" >> /etc/sudoers
       - USER giantswarm
 - name: amazon/opendistro-for-elasticsearch
   patterns:

--- a/images.yaml
+++ b/images.yaml
@@ -8,7 +8,8 @@
       - USER giantswarm
     - tagSuffix: giantswarm-sysctl
       dockerfileOptions:
-      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm && apk add --no-cache sudo && echo "giantswarm  ALL = NOPASSWD: /sbin/sysctl" >> /etc/sudoers
+      - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
+      - RUN apk add --no-cache sudo && echo "giantswarm  ALL = NOPASSWD: /sbin/sysctl" >> /etc/sudoers
       - USER giantswarm
 - name: amazon/opendistro-for-elasticsearch
   patterns:


### PR DESCRIPTION
towards https://github.com/giantswarm/nginx-ingress-controller-app/pull/60/files

this allows the non-root user to use `sudo` to execute commands (provided this is allowed by the relevant pod security policy)