### PR TITLE
Add component-specific images

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -225,6 +225,18 @@
 - name: k8s.gcr.io/cluster-autoscaler
   patterns:
   - pattern: '>= v1.15.4'
+- name: k8s.gcr.io/kube-apiserver
+  patterns:
+  - pattern: '>= v1.16'
+- name: k8s.gcr.io/kube-controller-manager
+  patterns:
+  - pattern: '>= v1.16'
+- name: k8s.gcr.io/kube-proxy
+  patterns:
+  - pattern: '>= v1.16'
+- name: k8s.gcr.io/kube-scheduler
+  patterns:
+  - pattern: '>= v1.16'
 - name: k8s.gcr.io/hyperkube
   patterns:
   - pattern: '>= v1.15'

--- a/images.yaml
+++ b/images.yaml
@@ -225,6 +225,9 @@
 - name: k8s.gcr.io/cluster-autoscaler
   patterns:
   - pattern: '>= v1.15.4'
+- name: k8s.gcr.io/hyperkube
+  patterns:
+  - pattern: '>= v1.15'
 - name: k8s.gcr.io/kube-apiserver
   patterns:
   - pattern: '>= v1.16'
@@ -237,9 +240,6 @@
 - name: k8s.gcr.io/kube-scheduler
   patterns:
   - pattern: '>= v1.16'
-- name: k8s.gcr.io/hyperkube
-  patterns:
-  - pattern: '>= v1.15'
 - name: k8s.gcr.io/metrics-server-amd64
   tags:
   - sha: 4ca116565ff6a46e582bada50ba3550f95b368db1d2415829241a565a6c38e2a

--- a/images.yaml
+++ b/images.yaml
@@ -230,16 +230,16 @@
   - pattern: '>= v1.15'
 - name: k8s.gcr.io/kube-apiserver
   patterns:
-  - pattern: '>= v1.16'
+  - pattern: '>= v1.16.9'
 - name: k8s.gcr.io/kube-controller-manager
   patterns:
-  - pattern: '>= v1.16'
+  - pattern: '>= v1.16.9'
 - name: k8s.gcr.io/kube-proxy
   patterns:
-  - pattern: '>= v1.16'
+  - pattern: '>= v1.16.9'
 - name: k8s.gcr.io/kube-scheduler
   patterns:
-  - pattern: '>= v1.16'
+  - pattern: '>= v1.16.9'
 - name: k8s.gcr.io/metrics-server-amd64
   tags:
   - sha: 4ca116565ff6a46e582bada50ba3550f95b368db1d2415829241a565a6c38e2a


### PR DESCRIPTION
Hyperkube is in the process of being deprecated so we should start retagging and using component-specific images such as kube-apiserver in our operators. We still need hyperkube for kubectl and kubelet until we find a better method so I haven't removed it.