### PR TITLE
Mask errors when execution fails due to reading or parsing yaml

### DIFF
--- a/pkg/images/error.go
+++ b/pkg/images/error.go
@@ -5,8 +5,3 @@ import "github.com/giantswarm/microerror"
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
-}

--- a/pkg/images/error.go
+++ b/pkg/images/error.go
@@ -1,0 +1,12 @@
+package images
+
+import "github.com/giantswarm/microerror"
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}

--- a/pkg/images/loader.go
+++ b/pkg/images/loader.go
@@ -14,7 +14,7 @@ func FromFile(filePath string) (Images, error) {
 	{
 		yamlFile, err = ioutil.ReadFile(filePath)
 		if err != nil {
-			return nil, microerror.Mask(err)
+			return nil, microerror.Maskf(executionFailedError, "failed to read file %#q with error %#q", filePath, err)
 		}
 	}
 
@@ -22,7 +22,7 @@ func FromFile(filePath string) (Images, error) {
 	{
 		err = yaml.Unmarshal(yamlFile, &images)
 		if err != nil {
-			return nil, microerror.Mask(err)
+			return nil, microerror.Maskf(executionFailedError, "failed to parse YAML file %#q with error %#q", filePath, err)
 		}
 	}
 	return images, nil


### PR DESCRIPTION
Followup to https://github.com/giantswarm/retagger/pull/361

Adds context to errors when loading the config file
