### PR TITLE
Add CA certs to alpine image

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -1,6 +1,6 @@
 - name: alpine
   patterns:
-  - pattern: '>= 3.9'
+  - pattern: '>= 3.11'
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:

--- a/images.yaml
+++ b/images.yaml
@@ -4,6 +4,7 @@
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:
+      - RUN apk add --no-cache ca-certificates
       - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
       - USER giantswarm
     - tagSuffix: giantswarm-sysctl


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/6290

This PR adds ca-certs and bumps the alpine version to the latest version.