### PR TITLE
Change image, set distinct versions for cluster-autoscaler

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -77,6 +77,14 @@
   tags:
   - sha: 72d816c99cc86b117baf04385020121f71015d7f5f9eba2a59e72532d645d38f
     tag: 7.6.1
+- name: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  tags:
+  - tag: v1.16.5
+    sha: aacbfd75b5cbbae9d9a663447e7b9ac42923136cc2487f93ea89e590f25c77a3
+  - tag: v1.15.6
+    sha: a367cb89efbc2eafcb6df98ce6cfaf8d098928ae23ca2da56a7d2e95fc825c44
+  - tag: v1.14.8
+    sha: 60a75bd24a4121adf5de16cdad76a52295d33aa8aa7c2945b4a9a1a8d2ac17f0
 - name: fluent/fluent-bit
   patterns:
   - pattern: '>= 1.x.x'
@@ -226,14 +234,6 @@
 - name: k8s.gcr.io/addon-resizer
   patterns:
   - pattern: '>= 1.8.7'
-- name: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
-  tags:
-  - tag: v1.16.5
-    sha: aacbfd75b5cbbae9d9a663447e7b9ac42923136cc2487f93ea89e590f25c77a3
-  - tag: v1.15.6
-    sha: a367cb89efbc2eafcb6df98ce6cfaf8d098928ae23ca2da56a7d2e95fc825c44
-  - tag: v1.14.8
-    sha: 60a75bd24a4121adf5de16cdad76a52295d33aa8aa7c2945b4a9a1a8d2ac17f0
 - name: k8s.gcr.io/hyperkube
   patterns:
   - pattern: '>= v1.15'

--- a/images.yaml
+++ b/images.yaml
@@ -226,9 +226,14 @@
 - name: k8s.gcr.io/addon-resizer
   patterns:
   - pattern: '>= 1.8.7'
-- name: k8s.gcr.io/cluster-autoscaler
-  patterns:
-  - pattern: '>= v1.15.4'
+- name: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  tags:
+  - tag: v1.16.5
+    sha: aacbfd75b5cbbae9d9a663447e7b9ac42923136cc2487f93ea89e590f25c77a3
+  - tag: v1.15.6
+    sha: a367cb89efbc2eafcb6df98ce6cfaf8d098928ae23ca2da56a7d2e95fc825c44
+  - tag: v1.14.8
+    sha: 60a75bd24a4121adf5de16cdad76a52295d33aa8aa7c2945b4a9a1a8d2ac17f0
 - name: k8s.gcr.io/hyperkube
   patterns:
   - pattern: '>= v1.15'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11112

- Since the registry and repo names for cluster-autoscaler have changed, the base `name` is updated.
- To pick up very specific versions only, we are defining the distinct SHA / tags combinations we want.