### PR TITLE
Retag external-dns from eu.gcr.io/k8s-artifacts-prod instead of zalando teapot registry

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -85,6 +85,9 @@
     sha: a367cb89efbc2eafcb6df98ce6cfaf8d098928ae23ca2da56a7d2e95fc825c44
   - tag: v1.14.8
     sha: 60a75bd24a4121adf5de16cdad76a52295d33aa8aa7c2945b4a9a1a8d2ac17f0
+- name: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns
+  patterns:
+  - pattern: '>= v0.6.0'
 - name: fluent/fluent-bit
   patterns:
   - pattern: '>= 1.x.x'
@@ -449,9 +452,6 @@
     tag: 3.2.11-alpine
   - sha: 87275ecd3017cdacd3e93eaf07e26f4a91d7f4d7c311b2305fccb50ec3a1a8cd
     tag: 4.0.9
-- name: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns
-  patterns:
-  - pattern: '>= v0.6.0'
 
 # Used in prometheus-operator-app
 - name: squareup/ghostunnel

--- a/images.yaml
+++ b/images.yaml
@@ -449,7 +449,7 @@
     tag: 3.2.11-alpine
   - sha: 87275ecd3017cdacd3e93eaf07e26f4a91d7f4d7c311b2305fccb50ec3a1a8cd
     tag: 4.0.9
-- name: registry.opensource.zalan.do/teapot/external-dns
+- name: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns
   patterns:
   - pattern: '>= v0.6.0'
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#11356