### PR TITLE
Retag pause-amd64 from k8s.gcr.io facade

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -103,10 +103,6 @@
     tag: "1.0"
   - sha: a64c8ed5df00c9f238ecdeb28eb4ed226faace573695e290a99d92d503593e87
     tag: "1.2"
-- name: gcr.io/google_containers/pause-amd64
-  tags:
-  - sha: 59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610
-    tag: "3.1"
 - name: gcr.io/heptio-images/eventrouter
   tags:
   - sha: dba60a88600d2d94fcd4c365e2931e54ae9aa495e94a924f80814e019b7ea046
@@ -248,6 +244,9 @@
   tags:
   - sha: 4b036e8844920336fa48f36edeb7d4398f426d6a934ba022848deed2edbf09aa
     tag: 1.0.0
+- name: k8s.gcr.io/pause-amd64
+  patterns:
+  - pattern: '>= 3.1'
 - name: kindest/node
   overrideRepoName: kind-node
   patterns:


### PR DESCRIPTION
Beside switching to use facade instead of deprecated `gcr.io/google_containers`, PR also changes ratg configuration from retagging just a fixed 3.1 tag, to retag by pattern, >=3.1.

See https://groups.google.com/d/msg/kubernetes-dev/MkXnkTSJ_vs/7wvClbkxAgAJ