### PR TITLE
Include retagging strimzi "pre-releases"

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -476,16 +476,16 @@
 # Used in strimzi-kafka-operator-app
 - name: strimzi/jmxtrans
   patterns:
-  - pattern: '>= 0.18.0'
+  - pattern: '>= 0.18.0-0'
 - name: strimzi/kafka
   patterns:
-  - pattern: '>= 0.18.0'
+  - pattern: '>= 0.18.0-0'
 - name: strimzi/kafka-bridge
   patterns:
-  - pattern: '>= 0.18.0'
+  - pattern: '>= 0.18.0-0'
 - name: strimzi/operator
   patterns:
-  - pattern: '>= 0.18.0'
+  - pattern: '>= 0.18.0-0'
 
 - name: sysdig/falco
   tags:


### PR DESCRIPTION
Strimzi for same release version publishes multiple kafka version specific variants/artifacts.

E.g. strimzi/kafka:0.18.0-kafka-2.5.0 and strimzi/kafka:0.18.0-kafka-2.4.1

These are recognized as pre-releases although they are proper releases.
