### PR TITLE
Add new source for configmap-reload for prometheus-operator-app.

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -210,13 +210,13 @@
   tags:
   - sha: 7dbe2ccfbf2eb7b29367f6a3ee7c0976c3b45e4e21d6363cb43b156c17488259
     tag: 9ee2ce8
+- name: jimmidyson/configmap-reload
+  patterns:
+  - pattern: '>= v0.2.0'
 - name: jimschubert/swagger-codegen-cli
   tags:
   - sha: 1d929c3de13d97fa351b2a76e48f306be6080d697cbbc4c1b6b6fb407f5d9a5e
     tag: 2.2.3
-- name: jimmidyson/configmap-reload
-  patterns:
-  - pattern: '>= v0.2.0'
 - name: jollinshead/journald-cloudwatch-logs
   tags:
   - sha: eea825329e678c5e259ffde8e07ffc1223e851f0018fbbb50b607f3fb5beefdb

--- a/images.yaml
+++ b/images.yaml
@@ -214,6 +214,9 @@
   tags:
   - sha: 1d929c3de13d97fa351b2a76e48f306be6080d697cbbc4c1b6b6fb407f5d9a5e
     tag: 2.2.3
+- name: jimmidyson/configmap-reload
+  patterns:
+  - pattern: '>= v0.2.0'
 - name: jollinshead/journald-cloudwatch-logs
   tags:
   - sha: eea825329e678c5e259ffde8e07ffc1223e851f0018fbbb50b607f3fb5beefdb
@@ -359,10 +362,6 @@
 - name: quay.io/coreos/configmap-reload
   patterns:
   - pattern: '>= v0.0.1'
-- name: docker.io/jimmidyson/configmap-reload
-  overrideRepoName: jd-configmap-reload
-  patterns:
-  - pattern: '>= v0.2.0'
 - name: quay.io/coreos/etcd
   patterns:
   - pattern: '>= v3.3'

--- a/images.yaml
+++ b/images.yaml
@@ -359,6 +359,10 @@
 - name: quay.io/coreos/configmap-reload
   patterns:
   - pattern: '>= v0.0.1'
+- name: docker.io/jimmidyson/configmap-reload
+  overrideRepoName: jd-configmap-reload
+  patterns:
+  - pattern: '>= v0.2.0'
 - name: quay.io/coreos/etcd
   patterns:
   - pattern: '>= v3.3'


### PR DESCRIPTION
For new image repos read the docs to create repos in our registries:
https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/

If you're an admin you can just ping SIG releng and force merge your PR once CI is green.

---
Add secondary source for configmap-reload for prometheus-operator where upstream-charts are using new image source and newer version.