### PR TITLE
Retag nginx controller from its new home

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -87,6 +87,10 @@
 - name: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns
   patterns:
   - pattern: '>= v0.6.0'
+- name: eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller
+  overrideRepoName: ingress-nginx-controller
+  patterns:
+  - pattern: '>= v0.34.0'
 - name: fluent/fluent-bit
   patterns:
   - pattern: '>= 1.x.x'


### PR DESCRIPTION
For new image repos read the docs to create repos in our registries:
https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/

If you're an admin you can just ping SIG releng and force merge your PR once CI is green.

---

See https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0340 for more info.

Keeping still old source retagging for the time being - will keep in mind to remove eventually if it is confirmed to be no longer used.