### PR TITLE
Fix istio operator name

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -133,6 +133,7 @@
   - sha: 9f2a352b44143c8c4dc72ea2df07d1b3c9d37e45a2ebcfa72c048cca17b9d6eb
     tag: v0.10.0
 - name: gcr.io/istio-testing/operator
+  overrideRepoName: istio-operator
   tags:
   - sha: 4fc41a76a237de912507d9644860d33cdf90bedf6477c795d7c64f79778d33a0
     tag: 1.7-dev


### PR DESCRIPTION
For new image repos read the docs to create repos in our registries:
https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/

If you're an admin you can just ping SIG releng and force merge your PR once CI is green.

---
