### PR TITLE
add opsgenie event exporter

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -303,6 +303,10 @@
 - name: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
   patterns:
   - pattern: '>= 0.7.0'
+- name: opsgenie/kubernetes-event-exporter
+  comment: used for https://github.com/giantswarm/event-exporter-app
+  patterns:
+  - pattern: '>= v0.9'
 - name: mcr.microsoft.com/k8s/aad-pod-identity/mic
   tags:
   - sha: bd9465be94966b9a917e1e3904fa5e63dd91772ccadf304e18ffd8e4ad8ccedd

--- a/images.yaml
+++ b/images.yaml
@@ -303,10 +303,6 @@
 - name: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
   patterns:
   - pattern: '>= 0.7.0'
-- name: opsgenie/kubernetes-event-exporter
-  comment: used for https://github.com/giantswarm/event-exporter-app
-  patterns:
-  - pattern: '>= v0.9'
 - name: mcr.microsoft.com/k8s/aad-pod-identity/mic
   tags:
   - sha: bd9465be94966b9a917e1e3904fa5e63dd91772ccadf304e18ffd8e4ad8ccedd
@@ -342,6 +338,10 @@
 - name: omnition/opencensus-collector
   patterns:
   - pattern: '>= 0.1.11'
+- name: opsgenie/kubernetes-event-exporter
+  comment: used for https://github.com/giantswarm/event-exporter-app
+  patterns:
+  - pattern: '>= v0.9'
 - name: peaceiris/hugo
   tags:
   - sha: 6cbae1884fd4c097c85d452d4ff9cde3bb8b198ced56ba2db8088dec5abf64db


### PR DESCRIPTION
I did a dry run locally. Looks good to me. Sanity check from somebody would be awesome. **Do I have to create the quay repo manually?**

```
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:31","level":"debug","message":"compiling jobs for image registry.hub.docker.com / opsgenie/kubernetes-event-exporter using pattern >= v0.9, with options retagger.JobOptions{DockerfileOptions:[]string(nil), TagSuffix:\"\", OverrideRepoName:\"\"}","time":"2020-09-21T12:26:28.197161+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.2 ","time":"2020-09-21T12:26:29.699262+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.2 does not fulfill constraint >= v0.9 because 0.2.0 is less than v0.9","time":"2020-09-21T12:26:29.699322+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.3 ","time":"2020-09-21T12:26:29.699339+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.3 does not fulfill constraint >= v0.9 because 0.3.0 is less than v0.9","time":"2020-09-21T12:26:29.699357+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.4 ","time":"2020-09-21T12:26:29.69937+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.4 does not fulfill constraint >= v0.9 because 0.4.0 is less than v0.9","time":"2020-09-21T12:26:29.717423+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.5 ","time":"2020-09-21T12:26:29.717463+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.5 does not fulfill constraint >= v0.9 because 0.5.0 is less than v0.9","time":"2020-09-21T12:26:29.717484+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.6 ","time":"2020-09-21T12:26:29.717499+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.6 does not fulfill constraint >= v0.9 because 0.6.0 is less than v0.9","time":"2020-09-21T12:26:29.717517+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.7 ","time":"2020-09-21T12:26:29.717531+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.7 does not fulfill constraint >= v0.9 because 0.7.0 is less than v0.9","time":"2020-09-21T12:26:29.717547+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.8 ","time":"2020-09-21T12:26:29.71756+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:139","level":"debug","message":"Image opsgenie/kubernetes-event-exporter:0.8 does not fulfill constraint >= v0.9 because 0.8.0 is less than v0.9","time":"2020-09-21T12:26:29.717576+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: 0.9 ","time":"2020-09-21T12:26:29.717589+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:131","level":"debug","message":"Checking external tag: latest ","time":"2020-09-21T12:26:29.717604+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:52","level":"debug","message":"Found 1 upstream tags which match the pattern >= v0.9","time":"2020-09-21T12:26:29.717621+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/registry/registry_quay.go:91","level":"debug","message":"requesting registry tags from https://quay.io/api/v1/repository/giantswarm/kubernetes-event-exporter/tag/","time":"2020-09-21T12:26:29.717644+00:00"}
{"caller":"github.com/giantswarm/retagger/pkg/registry/registry_quay.go:101","level":"warn","message":"unable to list tags for quay.io/giantswarm/kubernetes-event-exporter: HTTP 401 - Requires authentication. If the repository does not exist, retagger will try to create it. If the repository exists, check that the user has access to it","time":"2020-09-21T12:26:29.904061+00:00"}
```