### PR TITLE
Add Golang 1.15.2 image

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -196,6 +196,8 @@
   tags:
   - sha: 244a736db4a1d2611d257e7403c729663ce2eb08d4628868f9d9ef2735496659
     tag: 1.14.1-alpine3.11
+  - sha: 4d8abd16b03209b30b48f69a2e10347aacf7ce65d8f9f685e8c3e20a512234d9
+    tag: 1.15.2-alpine3.12
 - name: golangci/golangci-lint
   tags:
   - sha: 05764fbd373c2b2c44186b0a98774b37499cbe71d41854def5487ead8b9861b5


### PR DESCRIPTION
This is required for this https://github.com/giantswarm/architect/pull/513.

```
$ docker pull golang:1.15.2-alpine3.12 | grep sha | awk -F ':' '{print $3}'
4d8abd16b03209b30b48f69a2e10347aacf7ce65d8f9f685e8c3e20a512234d9
```