### PR TITLE
Add customeImage option for kong with lua-resty-openidc dependency

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -307,6 +307,10 @@
 - name: kong
   patterns:
   - pattern: '>= 1.4.3'
+  customImages:
+  - tagSuffix: lua-resty-openidc
+    dockerfileOptions:
+    - RUN luarocks install lua-resty-openidc 1.6.0
 - name: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
   patterns:
   - pattern: '>= 0.7.0'


### PR DESCRIPTION
For new image repos read the docs to create repos in our registries:
https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/

If you're an admin you can just ping SIG releng and force merge your PR once CI is green.

---
