### PR TITLE
add ebs-csi-driver

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -17,6 +17,9 @@
   tags:
   - sha: 9f670bbb42c30c9a2117c5a2cf924e49ba1d4d122cd673bdfbbca9fc031b9013
     tag: 2.0.24
+- name: amazon/aws-ebs-csi-driver
+  patterns:
+  - pattern: '>= 0.7.0'
 - name: amazon/opendistro-for-elasticsearch
   patterns:
   - pattern: '>= 1.3.0'
@@ -468,6 +471,24 @@
 - name: quay.io/jetstack/cert-manager-webhook
   patterns:
   - pattern: '>= v0.14.2'
+- name: quay.io/k8scsi/csi-attacher
+  patterns:
+  - pattern: '>= v1.2.0'
+- name: quay.io/k8scsi/csi-node-driver-registrar
+  patterns:
+  - pattern: '>= v1.1.0'
+- name: quay.io/k8scsi/csi-provisioner
+  patterns:
+  - pattern: '>= v1.6.0'
+- name: quay.io/k8scsi/csi-snapshotter
+  patterns:
+  - pattern: '>= v2.1.1'
+- name: quay.io/k8scsi/csi-resizer
+  patterns:
+  - pattern: '>= v0.3.0'
+- name: quay.io/k8scsi/livenessprobe
+  patterns:
+  - pattern: '>= v1.1.0'
 - name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
   patterns:
   - pattern: '>= v0.28.0'

--- a/images.yaml
+++ b/images.yaml
@@ -480,12 +480,12 @@
 - name: quay.io/k8scsi/csi-provisioner
   patterns:
   - pattern: '>= v1.6.0'
-- name: quay.io/k8scsi/csi-snapshotter
-  patterns:
-  - pattern: '>= v2.1.1'
 - name: quay.io/k8scsi/csi-resizer
   patterns:
   - pattern: '>= v0.3.0'
+- name: quay.io/k8scsi/csi-snapshotter
+  patterns:
+  - pattern: '>= v2.1.1'
 - name: quay.io/k8scsi/livenessprobe
   patterns:
   - pattern: '>= v1.1.0'


### PR DESCRIPTION
In preparation of moving away from in-tree EBS storage plugin, this includes the CSI driver for AWS EBS and all side containers which are needed. 

For new image repos read the docs to create repos in our registries:
https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/

If you're an admin you can just ping SIG releng and force merge your PR once CI is green.

---