### PR TITLE
improve TestImagesOrderedAlphabetically output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/giantswarm/microerror v0.2.0
 	github.com/giantswarm/micrologger v0.3.1
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/google/go-cmp v0.4.0
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -3,6 +3,8 @@ package images
 import (
 	"sort"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_RetaggedName(t *testing.T) {
@@ -135,9 +137,10 @@ func TestImagesOrderedAlphabetically(t *testing.T) {
 
 	if !sort.StringsAreSorted(imageNames) {
 		t.Logf("images are not sorted alphabetically")
-		t.Logf("have \n%v", imageNames)
-		sort.Strings(imageNames)
-		t.Logf("want \n%v", imageNames)
+		var sorted = make([]string, len(imageNames))
+		copy(sorted, imageNames)
+		sort.Strings(sorted)
+		t.Logf(cmp.Diff(imageNames, sorted))
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Before:

```
$ go test -v ./pkg/images/ -run TestImagesOrderedAlphabetically
=== RUN   TestImagesOrderedAlphabetically
    images_test.go:137: images are not sorted alphabetically
    images_test.go:138: have
        [alpine alpine/git amazon/aws-cli amazon/aws-ebs-csi-driver amazon/opendistro-for-elasticsearch amazon/opendistro-for-elasticsearch-kibana aquasec/kube-bench bitnami/kubectl bitnami/redis bobrik/curator busybox centos cibuilds/github coredns/coredns curlimages/curl dduportal/bats directxman12/k8s-prometheus-adapter-amd64 docker docker.elastic.co/elasticsearch/elasticsearch-oss docker.elastic.co/kibana/kibana-oss eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller fluent/fluent-bit fluent/fluentd-kubernetes-daemonset gcr.io/google-containers/startup-script gcr.io/google_containers/defaultbackend gcr.io/heptio-images/eventrouter gcr.io/heptio-images/gangway gcr.io/heptio-images/kube-conformance gcr.io/heptio-images/sonobuoy gcr.io/istio-testing/operator gcr.io/kubernetes-helm/tiller gfkse/oauth2_proxy goharbor/chartmuseum-photon goharbor/clair-photon goharbor/harbor-adminserver goharbor/harbor-db goharbor/harbor-jobservice goharbor/harbor-ui goharbor/notary-server-photon goharbor/notary-signer-photon goharbor/registry-photon golang golangci/golangci-lint grafana/grafana grafana/grafana-image-renderer grafana/loki grafana/promtail instrumenta/conftest jaegertracing/all-in-one jaegertracing/jaeger-operator jettech/kube-webhook-certgen jgsqware/fluentd-loki-plugin jimmidyson/configmap-reload jimschubert/swagger-codegen-cli jollinshead/journald-cloudwatch-logs justwatch/elasticsearch_exporter k8s.gcr.io/addon-resizer k8s.gcr.io/cluster-proportional-autoscaler-amd64 k8s.gcr.io/hyperkube k8s.gcr.io/kube-apiserver k8s.gcr.io/kube-controller-manager k8s.gcr.io/kube-proxy k8s.gcr.io/kube-scheduler k8s.gcr.io/metrics-server-amd64 k8s.gcr.io/nvidia-gpu-device-plugin k8s.gcr.io/pause k8s.gcr.io/pause-amd64 kindest/node kiwigrid/k8s-sidecar koalaman/shellcheck-alpine kong kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller mcr.microsoft.com/k8s/aad-pod-identity/mic mcr.microsoft.com/k8s/aad-pod-identity/nmi mintel/dex-k8s-authenticator mysql nginx nginxinc/nginx-unprivileged omnition/opencensus-collector opsgenie/kubernetes-event-exporter peaceiris/hugo prom/cloudwatch-exporter prom/prometheus prom/pushgateway quay.io/calico/cni quay.io/calico/kube-controllers quay.io/calico/node quay.io/calico/pod2daemon-flexvol quay.io/calico/typha quay.io/coreos/configmap-reload quay.io/coreos/etcd quay.io/coreos/etcd-operator quay.io/coreos/flannel quay.io/coreos/kube-state-metrics quay.io/coreos/prometheus-config-reloader quay.io/coreos/prometheus-operator quay.io/prometheus-operator/prometheus-config-reloader quay.io/prometheus-operator/prometheus-operator quay.io/dexidp/dex quay.io/fairwinds/goldilocks quay.io/fluentd_elasticsearch/fluentd quay.io/giantswarm/amazon-k8s-cni quay.io/giantswarm/docker-strongswan quay.io/giantswarm/k8s-api-healthz quay.io/giantswarm/k8s-setup-network-environment quay.io/helmpack/chart-testing quay.io/jacksontj/promxy quay.io/jetstack/cert-manager-cainjector quay.io/jetstack/cert-manager-controller quay.io/jetstack/cert-manager-ingress-shim quay.io/jetstack/cert-manager-webhook quay.io/k8scsi/csi-attacher quay.io/k8scsi/csi-node-driver-registrar quay.io/k8scsi/csi-provisioner quay.io/k8scsi/csi-resizer quay.io/k8scsi/csi-snapshotter quay.io/k8scsi/livenessprobe quay.io/kubernetes-ingress-controller/nginx-ingress-controller quay.io/open-policy-agent/gatekeeper quay.io/prometheus/alertmanager quay.io/prometheus/haproxy-exporter quay.io/prometheus/node-exporter quay.io/pusher/oauth2_proxy quay.io/uswitch/kiam redis squareup/ghostunnel strimzi/jmxtrans strimzi/kafka strimzi/kafka-bridge strimzi/operator sysdig/falco toniblyx/prowler untergeek/curator vault weaveworks/watch zricethezav/gitleaks]
    images_test.go:140: want
        [alpine alpine/git amazon/aws-cli amazon/aws-ebs-csi-driver amazon/opendistro-for-elasticsearch amazon/opendistro-for-elasticsearch-kibana aquasec/kube-bench bitnami/kubectl bitnami/redis bobrik/curator busybox centos cibuilds/github coredns/coredns curlimages/curl dduportal/bats directxman12/k8s-prometheus-adapter-amd64 docker docker.elastic.co/elasticsearch/elasticsearch-oss docker.elastic.co/kibana/kibana-oss eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller fluent/fluent-bit fluent/fluentd-kubernetes-daemonset gcr.io/google-containers/startup-script gcr.io/google_containers/defaultbackend gcr.io/heptio-images/eventrouter gcr.io/heptio-images/gangway gcr.io/heptio-images/kube-conformance gcr.io/heptio-images/sonobuoy gcr.io/istio-testing/operator gcr.io/kubernetes-helm/tiller gfkse/oauth2_proxy goharbor/chartmuseum-photon goharbor/clair-photon goharbor/harbor-adminserver goharbor/harbor-db goharbor/harbor-jobservice goharbor/harbor-ui goharbor/notary-server-photon goharbor/notary-signer-photon goharbor/registry-photon golang golangci/golangci-lint grafana/grafana grafana/grafana-image-renderer grafana/loki grafana/promtail instrumenta/conftest jaegertracing/all-in-one jaegertracing/jaeger-operator jettech/kube-webhook-certgen jgsqware/fluentd-loki-plugin jimmidyson/configmap-reload jimschubert/swagger-codegen-cli jollinshead/journald-cloudwatch-logs justwatch/elasticsearch_exporter k8s.gcr.io/addon-resizer k8s.gcr.io/cluster-proportional-autoscaler-amd64 k8s.gcr.io/hyperkube k8s.gcr.io/kube-apiserver k8s.gcr.io/kube-controller-manager k8s.gcr.io/kube-proxy k8s.gcr.io/kube-scheduler k8s.gcr.io/metrics-server-amd64 k8s.gcr.io/nvidia-gpu-device-plugin k8s.gcr.io/pause k8s.gcr.io/pause-amd64 kindest/node kiwigrid/k8s-sidecar koalaman/shellcheck-alpine kong kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller mcr.microsoft.com/k8s/aad-pod-identity/mic mcr.microsoft.com/k8s/aad-pod-identity/nmi mintel/dex-k8s-authenticator mysql nginx nginxinc/nginx-unprivileged omnition/opencensus-collector opsgenie/kubernetes-event-exporter peaceiris/hugo prom/cloudwatch-exporter prom/prometheus prom/pushgateway quay.io/calico/cni quay.io/calico/kube-controllers quay.io/calico/node quay.io/calico/pod2daemon-flexvol quay.io/calico/typha quay.io/coreos/configmap-reload quay.io/coreos/etcd quay.io/coreos/etcd-operator quay.io/coreos/flannel quay.io/coreos/kube-state-metrics quay.io/coreos/prometheus-config-reloader quay.io/coreos/prometheus-operator quay.io/dexidp/dex quay.io/fairwinds/goldilocks quay.io/fluentd_elasticsearch/fluentd quay.io/giantswarm/amazon-k8s-cni quay.io/giantswarm/docker-strongswan quay.io/giantswarm/k8s-api-healthz quay.io/giantswarm/k8s-setup-network-environment quay.io/helmpack/chart-testing quay.io/jacksontj/promxy quay.io/jetstack/cert-manager-cainjector quay.io/jetstack/cert-manager-controller quay.io/jetstack/cert-manager-ingress-shim quay.io/jetstack/cert-manager-webhook quay.io/k8scsi/csi-attacher quay.io/k8scsi/csi-node-driver-registrar quay.io/k8scsi/csi-provisioner quay.io/k8scsi/csi-resizer quay.io/k8scsi/csi-snapshotter quay.io/k8scsi/livenessprobe quay.io/kubernetes-ingress-controller/nginx-ingress-controller quay.io/open-policy-agent/gatekeeper quay.io/prometheus-operator/prometheus-config-reloader quay.io/prometheus-operator/prometheus-operator quay.io/prometheus/alertmanager quay.io/prometheus/haproxy-exporter quay.io/prometheus/node-exporter quay.io/pusher/oauth2_proxy quay.io/uswitch/kiam redis squareup/ghostunnel strimzi/jmxtrans strimzi/kafka strimzi/kafka-bridge strimzi/operator sysdig/falco toniblyx/prowler untergeek/curator vault weaveworks/watch zricethezav/gitleaks]
--- FAIL: TestImagesOrderedAlphabetically (0.00s)
FAIL
FAIL    github.com/giantswarm/retagger/pkg/images       0.004s
FAIL
```

After:

```
$ go test -v ./pkg/images/ -run TestImagesOrderedAlphabetically
=== RUN   TestImagesOrderedAlphabetically
    images_test.go:139: images are not sorted alphabetically
    images_test.go:143:   []string{
                ... // 96 identical elements
                "quay.io/coreos/prometheus-config-reloader",
                "quay.io/coreos/prometheus-operator",
        -       "quay.io/prometheus-operator/prometheus-config-reloader",
        -       "quay.io/prometheus-operator/prometheus-operator",
                "quay.io/dexidp/dex",
                "quay.io/fairwinds/goldilocks",
                ... // 17 identical elements
                "quay.io/kubernetes-ingress-controller/nginx-ingress-controller",
                "quay.io/open-policy-agent/gatekeeper",
        +       "quay.io/prometheus-operator/prometheus-config-reloader",
        +       "quay.io/prometheus-operator/prometheus-operator",
                "quay.io/prometheus/alertmanager",
                "quay.io/prometheus/haproxy-exporter",
                ... // 15 identical elements
          }
--- FAIL: TestImagesOrderedAlphabetically (0.00s)
FAIL
FAIL    github.com/giantswarm/retagger/pkg/images       0.005s
FAIL
```