### PR TITLE
remove PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-
-For new image repos read the docs to create repos in our registries:
-https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/
-
-If you're an admin you can just ping SIG releng and force merge your PR once CI is green.
-
----


### PR DESCRIPTION
Removing the PR template, because we do not need to create registries manually anymore.