### PR TITLE
Add elasticsearch

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -95,6 +95,10 @@
   tags:
   - sha: 72d816c99cc86b117baf04385020121f71015d7f5f9eba2a59e72532d645d38f
     tag: 7.6.1
+- name: elasticsearch
+  tags:
+  - tag: 6.8.13
+    sha: 8d4e29332dc159e7c256efa131453bd62a35b6e90f32aa9ab3f76632e29372c3
 - name: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
   tags:
   - tag: v1.19.1


### PR DESCRIPTION
Adding the latest `elasticsearch` 6.8 image, which we intend to use in https://github.com/giantswarm/sitesearch