### PR TITLE
Skip basic job when options are specified

### DIFF
--- a/pkg/retagger/job_definition.go
+++ b/pkg/retagger/job_definition.go
@@ -117,23 +117,26 @@ func fromImageTagPatternIncludeCustom(image images.Image, pattern images.TagPatt
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	jobs = append(jobs, j)
 
-	for _, c := range pattern.CustomImages {
-		j, err = fromImageTagPattern(image, pattern)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		if c.TagSuffix != "" {
-			j.Options.TagSuffix = c.TagSuffix
-		}
-
-		if c.DockerfileOptions != nil && len(c.DockerfileOptions) > 0 {
-			j.Options.DockerfileOptions = c.DockerfileOptions
-		}
-
+	if len(pattern.CustomImages) == 0 {
 		jobs = append(jobs, j)
+	} else {
+		for _, c := range pattern.CustomImages {
+			j, err = fromImageTagPattern(image, pattern)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+			if c.TagSuffix != "" {
+				j.Options.TagSuffix = c.TagSuffix
+			}
+
+			if c.DockerfileOptions != nil && len(c.DockerfileOptions) > 0 {
+				j.Options.DockerfileOptions = c.DockerfileOptions
+			}
+
+			jobs = append(jobs, j)
+		}
 	}
 
 	return jobs, nil

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -62,7 +62,7 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 
 	for _, match := range matches {
 		j := SingleJob{
-			Source: job.Source,
+			Source:  job.Source,
 			Options: job.Options,
 		}
 

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -61,25 +61,23 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 	var jobs []SingleJob
 
 	for _, match := range matches {
-		_, exists := existingTagMap[match]
+		j := SingleJob{
+			Source: job.Source,
+			Options: job.Options,
+		}
+
+		// Override Source options from our pattern.
+		j.Source.Tag = match
+		j.Destination = GetDestinationForJob(&j, r)
+
+		_, exists := existingTagMap[j.Destination.Tag]
 		if !exists {
 			// Tag is new - get SHA and tag it.
 			newDigest, err := externalRegistry.ManifestV2Digest(job.Source.FullImageName, match)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
-			sourceSHA := strings.TrimPrefix(newDigest.String(), "sha256:")
-			// Create job with new SHA.
-			j := SingleJob{
-
-				Source: job.Source,
-
-				Options: job.Options,
-			}
-			// Override Source options from our pattern.
-			j.Source.Tag = match
-			j.Source.SHA = sourceSHA
-			j.Destination = GetDestinationForJob(&j, r)
+			j.Source.SHA = strings.TrimPrefix(newDigest.String(), "sha256:")
 			jobs = append(jobs, j)
 		}
 	}


### PR DESCRIPTION
I'm fixing two problems here. The first is that we convert an image with a pattern into two jobs: one without the options/suffix (e.g. `quay.io/giantswarm/kube-apiserver:v1.19.5`), and one with the options suffix (e.g. `quay.io/giantswarm/kube-apiserver:v1.19.5-giantswarm`). I think it's reasonable to assume that if we have options specified, we don't also need the image without options. This will make runs go a little faster. I can revert this if others disagree.

The other problem is that we check the existing tags in Quay/Aliyun without considering the suffix. This means it's random whether we'll push "quay.io/giantswarm/kube-apiserver:v1.19.5-giantswarm" or "quay.io/giantswarm/kube-apiserver:v1.19.5" and usually we push the one without the suffix as seen in the container registry https://quay.io/repository/giantswarm/kube-apiserver?tab=tags By calculating the destination tag first and then checking for its existence, we always push the image with the suffix if it's missing.