### PR TITLE
Remove custom image for kube-apiserver 1.19+

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -318,15 +318,8 @@
   - pattern: '>= v1.15'
 - name: k8s.gcr.io/kube-apiserver
   patterns:
+  - pattern: '>= v1.19.0'
   - pattern: '>= v1.16.8'
-    customImages:
-    - tagSuffix: giantswarm
-      dockerfileOptions:
-      - RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-  tags:
-  # Force 1.16.9 to be retagged with dockerfileOptions.
-  - sha: 4a6df5f6a19b533c578c25fb276d34cd33f0f3013c25e854244011fa9f1cde5a
-    tag: v1.16.9
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:


### PR DESCRIPTION
Reverting https://github.com/giantswarm/retagger/pull/456 for 1.19+ because the certs are now included and `/bin/sh` is not.
