### PR TITLE
Restrict custom image to <1.19

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -319,7 +319,7 @@
 - name: k8s.gcr.io/kube-apiserver
   patterns:
   - pattern: '>= v1.19.0'
-  - pattern: '>= v1.16.8'
+  - pattern: '>= v1.16.8 < v1.19'
     customImages:
     - tagSuffix: giantswarm
       dockerfileOptions:


### PR DESCRIPTION
In https://app.circleci.com/pipelines/github/giantswarm/retagger/500/workflows/e65eb4e8-3bb0-4465-88e1-fea847498e42/jobs/3774 we see that k8s.gcr.io/kube-apiserver@sha256:6257f45b4908eed0a4b84d8efeaf2751096ce516006daf74690b321b785e6cc4 is failing. `docker run k8s.gcr.io/kube-apiserver@sha256:6257f45b4908eed0a4b84d8efeaf2751096ce516006daf74690b321b785e6cc4 /usr/local/bin/kube-apiserver --version` shows that this is v1.19.0 so we're still using custom image for 1.19.