### PR TITLE
Updating ebs csi registry

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -307,9 +307,6 @@
 - name: k8s.gcr.io/autoscaling/vpa-updater
   patterns:
   - pattern: '>= 0.8.0'
-- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  patterns:
-  - pattern: '>= 0.7.0'
 - name: k8s.gcr.io/cluster-proportional-autoscaler-amd64
   patterns:
   - pattern: '>= 1.6.0'
@@ -347,6 +344,9 @@
 - name: k8s.gcr.io/pause-amd64
   patterns:
   - pattern: '>= 3.1'
+- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  patterns:
+  - pattern: '>= 0.7.0'
 - name: kindest/node
   overrideRepoName: kind-node
   patterns:

--- a/images.yaml
+++ b/images.yaml
@@ -28,9 +28,6 @@
   tags:
   - sha: 9f670bbb42c30c9a2117c5a2cf924e49ba1d4d122cd673bdfbbca9fc031b9013
     tag: 2.0.24
-- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  patterns:
-  - pattern: '>= 0.7.0'
 - name: amazon/opendistro-for-elasticsearch
   patterns:
   - pattern: '>= 1.3.0'
@@ -310,6 +307,9 @@
 - name: k8s.gcr.io/autoscaling/vpa-updater
   patterns:
   - pattern: '>= 0.8.0'
+- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  patterns:
+  - pattern: '>= 0.7.0'
 - name: k8s.gcr.io/cluster-proportional-autoscaler-amd64
   patterns:
   - pattern: '>= 1.6.0'

--- a/images.yaml
+++ b/images.yaml
@@ -28,7 +28,7 @@
   tags:
   - sha: 9f670bbb42c30c9a2117c5a2cf924e49ba1d4d122cd673bdfbbca9fc031b9013
     tag: 2.0.24
-- name: amazon/aws-ebs-csi-driver
+- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
   patterns:
   - pattern: '>= 0.7.0'
 - name: amazon/opendistro-for-elasticsearch


### PR DESCRIPTION
EBS CSI Registry has been moved to k8s.gcr.io/provider-aws/aws-ebs-csi-driver

For new image repos read the docs to create repos in our registries:
https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-registry/

If you're an admin you can just ping SIG releng and force merge your PR once CI is green.

---