### PR TITLE
Replace hyperkube repo

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -374,6 +374,24 @@
     - tagSuffix: giantswarm
       dockerfileOptions:
       - RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+- name: k8s.gcr.io/kube-apiserver
+  tagTrimVersionPrefix: true
+  overrideRepoName: hyperkube
+  patterns:
+    - pattern: '>= v1.19.8 || >= v1.20.0-0'
+      customImages:
+        - dockerfileOptions:
+            - |
+              FROM quay.io/giantswarm/alpine:3.12.1 AS downloader
+              WORKDIR /tmp/hyperkube
+              COPY --from=0 /usr/local/bin/kube-apiserver /tmp/hyperkube/kube-apiserver
+              RUN KUBERNETES_VERSION=$(/tmp/hyperkube/kube-apiserver --version | grep Kubernetes | cut -d ' ' -f 2) && \
+              wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
+              wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+              chmod +x /tmp/hyperkube/kubelet /tmp/hyperkube/kubectl
+              FROM scratch
+              COPY --from=downloader /tmp/hyperkube/kubelet /kubelet
+              COPY --from=downloader /tmp/hyperkube/kubectl /kubectl
 - name: k8s.gcr.io/kube-controller-manager
   patterns:
   - pattern: '>= v1.16.8'

--- a/images.yaml
+++ b/images.yaml
@@ -378,20 +378,20 @@
   tagTrimVersionPrefix: true
   overrideRepoName: hyperkube
   patterns:
-    - pattern: '>= v1.19.8 || >= v1.20.0-0'
-      customImages:
-        - dockerfileOptions:
-            - |
-              FROM quay.io/giantswarm/alpine:3.12.1 AS downloader
-              WORKDIR /tmp/hyperkube
-              COPY --from=0 /usr/local/bin/kube-apiserver /tmp/hyperkube/kube-apiserver
-              RUN KUBERNETES_VERSION=$(/tmp/hyperkube/kube-apiserver --version | grep Kubernetes | cut -d ' ' -f 2) && \
-              wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
-              wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
-              chmod +x /tmp/hyperkube/kubelet /tmp/hyperkube/kubectl
-              FROM scratch
-              COPY --from=downloader /tmp/hyperkube/kubelet /kubelet
-              COPY --from=downloader /tmp/hyperkube/kubectl /kubectl
+  - pattern: '>= v1.19.8 || >= v1.20.0-0'
+    customImages:
+    - dockerfileOptions:
+      - |
+        FROM quay.io/giantswarm/alpine:3.12.1 AS downloader
+        WORKDIR /tmp/hyperkube
+        COPY --from=0 /usr/local/bin/kube-apiserver /tmp/hyperkube/kube-apiserver
+        RUN KUBERNETES_VERSION=$(/tmp/hyperkube/kube-apiserver --version | grep Kubernetes | cut -d ' ' -f 2) && \
+        wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
+        wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+        chmod +x /tmp/hyperkube/kubelet /tmp/hyperkube/kubectl
+        FROM scratch
+        COPY --from=downloader /tmp/hyperkube/kubelet /kubelet
+        COPY --from=downloader /tmp/hyperkube/kubectl /kubectl
 - name: k8s.gcr.io/kube-controller-manager
   patterns:
   - pattern: '>= v1.16.8'

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -9,11 +9,12 @@ type Images []Image
 
 // Image defines the data we process about a docker image.
 type Image struct {
-	Name             string       `yaml:"name"`
-	Comment          string       `yaml:"comment,omitempty"`
-	OverrideRepoName string       `yaml:"overrideRepoName,omitempty"`
-	Patterns         []TagPattern `yaml:"patterns"`
-	Tags             []Tag        `yaml:"tags"`
+	Name                 string       `yaml:"name"`
+	Comment              string       `yaml:"comment,omitempty"`
+	TagTrimVersionPrefix bool         `yaml:"tagTrimVersionPrefix,omitempty"`
+	OverrideRepoName     string       `yaml:"overrideRepoName,omitempty"`
+	Patterns             []TagPattern `yaml:"patterns"`
+	Tags                 []Tag        `yaml:"tags"`
 }
 
 // TagPattern represents a group of tags defined by a regular expression,

--- a/pkg/registry/registry_docker.go
+++ b/pkg/registry/registry_docker.go
@@ -169,7 +169,7 @@ func (r *Registry) logDocker(reader io.Reader) error {
 			return microerror.Maskf(dockerError, "docker task failed: %s", logMsg)
 		}
 
-		r.logger.Log("level", "debug", "message", fmt.Sprintf("docker status"), "docker", string(s.Bytes()))
+		r.logger.Log("level", "debug", "message", "docker status", "docker", string(s.Bytes()))
 	}
 	if err := s.Err(); err != nil {
 		return microerror.Mask(err)

--- a/pkg/retagger/executor.go
+++ b/pkg/retagger/executor.go
@@ -59,14 +59,14 @@ func (r *Retagger) executeSingleJob(job SingleJob) error {
 	}
 
 	if shouldTag {
-		r.logger.Log("level", "debug", "message", fmt.Sprintf("pulling original image"))
+		r.logger.Log("level", "debug", "message", "pulling original image")
 
 		err = r.registry.PullImage(job.Source.Image, job.Source.SHA)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.Log("level", "debug", "message", fmt.Sprintf("pulled original image"))
+		r.logger.Log("level", "debug", "message", "pulled original image")
 
 		if job.Options.DockerfileOptions != nil && len(job.Options.DockerfileOptions) > 0 {
 			_, err = r.registry.RebuildImage(job.Source.Image, job.Source.SHA, job.Destination.Image, job.Destination.Tag, job.Options.DockerfileOptions)

--- a/pkg/retagger/job.go
+++ b/pkg/retagger/job.go
@@ -20,6 +20,8 @@ type JobOptions struct {
 
 	TagSuffix string
 
+	TagTrimVersionPrefix bool
+
 	OverrideRepoName string
 }
 

--- a/pkg/retagger/job_definition.go
+++ b/pkg/retagger/job_definition.go
@@ -147,10 +147,10 @@ func fromImageTag(image images.Image, tag images.Tag) (JobDefinition, error) {
 		SourceImage: image.Name,
 		SourceTag:   tag.Tag,
 		SourceSha:   tag.Sha,
-	}
-
-	if image.OverrideRepoName != "" {
-		j.Options.OverrideRepoName = image.OverrideRepoName
+		Options: JobOptions{
+			TagTrimVersionPrefix: image.TagTrimVersionPrefix,
+			OverrideRepoName:     image.OverrideRepoName,
+		},
 	}
 
 	return j, nil
@@ -160,10 +160,10 @@ func fromImageTagPattern(image images.Image, tagPattern images.TagPattern) (JobD
 	j := JobDefinition{
 		SourceImage:   image.Name,
 		SourcePattern: tagPattern.Pattern,
-	}
-
-	if image.OverrideRepoName != "" {
-		j.Options.OverrideRepoName = image.OverrideRepoName
+		Options: JobOptions{
+			TagTrimVersionPrefix: image.TagTrimVersionPrefix,
+			OverrideRepoName:     image.OverrideRepoName,
+		},
 	}
 
 	return j, nil

--- a/pkg/retagger/job_single.go
+++ b/pkg/retagger/job_single.go
@@ -66,6 +66,9 @@ func GetDestinationForJob(j CompilableJob, r *Retagger) Destination {
 		} else {
 			destinationTag = fmt.Sprintf("%s-%s", j.GetSource().Tag, j.GetOptions().TagSuffix)
 		}
+		if j.GetOptions().TagTrimVersionPrefix {
+			destinationTag = strings.TrimPrefix(destinationTag, "v")
+		}
 	}
 	return Destination{
 		Image: destinationImage,


### PR DESCRIPTION
I realized that we could generate the `hyperkube` image dynamically in `retagger` with only a few changes by watching an upstream kubernetes image to get the version and then use a custom dockerfile to build the image using that version by downloading binaries. This replaces the https://github.com/giantswarm/hyperkube repo and allows us to new versions as soon as they are released without the Dependabot and release rigamarole.