### PR TITLE
Update architect to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install architect
           command: |
-            wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+            wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | grep linux | cut -d '"' -f 4) -O architect
             chmod +x ./architect
             ./architect version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install architect
           command: |
-            curl -sSL $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | grep linux | cut -d '"' -f 4) | tar xv --strip-components=1
+            curl -sSL $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | grep linux | cut -d '"' -f 4) | tar xzv --strip-components=1
             chmod +x ./architect
             ./architect version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install architect
           command: |
-            wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | grep linux | cut -d '"' -f 4) -O architect
+            curl -sSL $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | grep linux | cut -d '"' -f 4) | tar xv --strip-components=1
             chmod +x ./architect
             ./architect version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install architect
           command: |
-            wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v1.0.0 | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+            wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
             chmod +x ./architect
             ./architect version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install architect
           command: |
-            curl -sSL $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v3.2.1 | grep browser_download_url | grep linux | cut -d '"' -f 4) | tar xzv --strip-components=1
+            curl -sSL $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v2.1.6 | grep browser_download_url | grep linux | cut -d '"' -f 4) | tar xzv --strip-components=1
             chmod +x ./architect
             ./architect version
 


### PR DESCRIPTION
I noticed we were still on architect v1. I couldn't go to v3 because `build` is gone in that version. I think retagger will need to be migrated to architect orb to use anything newer. Hopefully there are some minor improvements here at least.