### PR TITLE
Add python:3.9-alpine3.13

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -516,6 +516,8 @@
   tags:
   - sha: 1263b94facc6fd812688f78e05a9e64497e96e21db7e3935be36c87fab038c7e
     tag: 3.8.6-slim
+  - sha: db35c8d2e810559d90af0a126dac55cf93601202061d3f61f94ac3c460d4a211
+    tag: 3.9-alpine3.13
 - name: quay.io/calico/cni
   patterns:
   - pattern: '>= v3.9.5'


### PR DESCRIPTION
To prevent Docker hub rate limiting problems like we had with https://github.com/giantswarm/docs/runs/1824733775?check_suite_focus=true , I am adding the image we use for scripts in giantswarm/docs.