### PR TITLE
Add coredns/coredns 1.8.3 image

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -76,6 +76,9 @@
   - sha: 9029b2f52ecd28aacec2fd8a86a321dc9f77a46df251de5e3f157dd6e80baea0
     tag: 0.12
 - name: coredns/coredns
+  tags:
+  - sha: db4f1c57978d7372b50f416d1058beb60cebff9a0d5b8bee02bfe70302e1cb2f
+    tag: 1.8.3
   patterns:
   - pattern: '>= 1.6.5'
     customImages:

--- a/images.yaml
+++ b/images.yaml
@@ -77,7 +77,7 @@
     tag: 0.12
 - name: coredns/coredns
   tags:
-  - sha: db4f1c57978d7372b50f416d1058beb60cebff9a0d5b8bee02bfe70302e1cb2f
+  - sha: 642ff9910da6ea9a8624b0234eef52af9ca75ecbec474c5507cb096bdfbae4e5
     tag: 1.8.3
   patterns:
   - pattern: '>= 1.6.5'


### PR DESCRIPTION
Manually add coredns 1.8.3 . Since PR #515, base images are not pushed by default when a custom image is specified. 