### PR TITLE
adding kube-rbac-proxy

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -246,6 +246,9 @@
   tags:
   - sha: 4fc41a76a237de912507d9644860d33cdf90bedf6477c795d7c64f79778d33a0
     tag: 1.7
+- name: gcr.io/kubebuilder/kube-rbac-proxy
+  patterns:
+  - pattern: '>= v0.4.1'
 - name: gcr.io/kubernetes-helm/tiller
   tags:
   - sha: 59b6200a822ddb18577ca7120fb644a3297635f47d92db521836b39b74ad19e8


### PR DESCRIPTION
the `kube-rbac-proxy` is used by the CAPI controllers. Adding them here because of imagepullbackoffs in China.
Towards https://github.com/giantswarm/giantswarm/issues/16080