### PR TITLE
Retag k8s pre-releases starting with 1.20

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -428,7 +428,7 @@
   - pattern: '>= v1.15'
 - name: k8s.gcr.io/kube-apiserver
   patterns:
-  - pattern: '>= v1.19.0'
+  - pattern: '>= v1.19.0 || >= v1.20.0-0'
   - pattern: '>= v1.16.8 < v1.19'
     customImages:
     - tagSuffix: giantswarm
@@ -454,13 +454,13 @@
         COPY --from=downloader /tmp/hyperkube/kubectl /kubectl
 - name: k8s.gcr.io/kube-controller-manager
   patterns:
-  - pattern: '>= v1.16.8'
+  - pattern: '>= v1.16.8 || >= v1.20.0-0'
 - name: k8s.gcr.io/kube-proxy
   patterns:
-  - pattern: '>= v1.16.8'
+  - pattern: '>= v1.16.8 || >= v1.20.0-0'
 - name: k8s.gcr.io/kube-scheduler
   patterns:
-  - pattern: '>= v1.16.8'
+  - pattern: '>= v1.16.8 || >= v1.20.0-0'
 - name: k8s.gcr.io/metrics-server/metrics-server
   tags:
   - sha: 78035f05bcf7e0f9b401bae1ac62b5a505f95f9c2122b80cff73dcc04d58497e


### PR DESCRIPTION
We don't have a story for this, but I've been wanting to start tracking upstream more closely so we can catch breaking changes earlier. We're already retagging this pattern for hyperkube (kubectl, kubelet) so this just makes all of the other components available as well. The `-0` suffix matches all pre-production semver releases (see https://quay.io/repository/giantswarm/hyperkube?tab=tags for proof).