### PR TITLE
Exclude quay.io/calico/kube-controllers v3.19.2 as it's breaking the execution

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -637,10 +637,8 @@
 - name: quay.io/calico/kube-controllers
   overrideRepoName: calico-crd-installer
   patterns:
-  # v3.19.2 is not functional, so we treat is "as is" without
-  # applying our additional build options.
-  - pattern: '== v3.19.2'
-  - pattern: '>= v3.15.0'
+  # Skip v3.19.2 as it's not functional
+  - pattern: '>= v3.15.0 || != v3.19.2'
     customImages:
     - dockerfileOptions:
       - |

--- a/images.yaml
+++ b/images.yaml
@@ -634,26 +634,27 @@
 - name: quay.io/calico/kube-controllers
   patterns:
   - pattern: '>= v3.9.5'
-# Deactivated since this breaks.
-# See https://gigantic.slack.com/archives/C3C7ZQXC1/p1628262522004900
-# - name: quay.io/calico/kube-controllers
-#   overrideRepoName: calico-crd-installer
-#   patterns:
-#   - pattern: '>= v3.15.0'
-#     customImages:
-#     - dockerfileOptions:
-#       - |
-#         FROM quay.io/giantswarm/crd-installer:0.1.1 AS installer
-#         FROM quay.io/giantswarm/alpine:3.13.5 AS downloader
-#         WORKDIR /tmp/crd-installer
-#         COPY --from=0 /usr/bin/kube-controllers /crd-installer/kube-controllers
-#         COPY --from=installer /scripts /scripts
-#         RUN CALICO_VERSION=$(/crd-installer/kube-controllers -version) && \
-#             /scripts/download-calico-crds.sh $CALICO_VERSION
-#         FROM scratch
-#         COPY --from=downloader /tmp/crd-installer/crds /crds
-#         COPY --from=installer /usr/local/bin/crd-installer /usr/local/bin/crd-installer
-#         CMD ["/usr/local/bin/crd-installer", "-dir", "/crds"]
+- name: quay.io/calico/kube-controllers
+  overrideRepoName: calico-crd-installer
+  patterns:
+  # v3.19.2 is not functional, so we treat is "as is" without
+  # applying our additional build options.
+  - pattern: '== v3.19.2'
+  - pattern: '>= v3.15.0'
+    customImages:
+    - dockerfileOptions:
+      - |
+        FROM quay.io/giantswarm/crd-installer:0.1.1 AS installer
+        FROM quay.io/giantswarm/alpine:3.13.5 AS downloader
+        WORKDIR /tmp/crd-installer
+        COPY --from=0 /usr/bin/kube-controllers /crd-installer/kube-controllers
+        COPY --from=installer /scripts /scripts
+        RUN CALICO_VERSION=$(/crd-installer/kube-controllers -version) && \
+            /scripts/download-calico-crds.sh $CALICO_VERSION
+        FROM scratch
+        COPY --from=downloader /tmp/crd-installer/crds /crds
+        COPY --from=installer /usr/local/bin/crd-installer /usr/local/bin/crd-installer
+        CMD ["/usr/local/bin/crd-installer", "-dir", "/crds"]
 - name: quay.io/calico/node
   patterns:
   - pattern: '>= v3.9.5'

--- a/images.yaml
+++ b/images.yaml
@@ -634,24 +634,26 @@
 - name: quay.io/calico/kube-controllers
   patterns:
   - pattern: '>= v3.9.5'
-- name: quay.io/calico/kube-controllers
-  overrideRepoName: calico-crd-installer
-  patterns:
-  - pattern: '>= v3.15.0'
-    customImages:
-    - dockerfileOptions:
-      - |
-        FROM quay.io/giantswarm/crd-installer:0.1.1 AS installer
-        FROM quay.io/giantswarm/alpine:3.13.5 AS downloader
-        WORKDIR /tmp/crd-installer
-        COPY --from=0 /usr/bin/kube-controllers /crd-installer/kube-controllers
-        COPY --from=installer /scripts /scripts
-        RUN CALICO_VERSION=$(/crd-installer/kube-controllers -version) && \
-            /scripts/download-calico-crds.sh $CALICO_VERSION
-        FROM scratch
-        COPY --from=downloader /tmp/crd-installer/crds /crds
-        COPY --from=installer /usr/local/bin/crd-installer /usr/local/bin/crd-installer
-        CMD ["/usr/local/bin/crd-installer", "-dir", "/crds"]
+# Deactivated since this breaks.
+# See https://gigantic.slack.com/archives/C3C7ZQXC1/p1628262522004900
+# - name: quay.io/calico/kube-controllers
+#   overrideRepoName: calico-crd-installer
+#   patterns:
+#   - pattern: '>= v3.15.0'
+#     customImages:
+#     - dockerfileOptions:
+#       - |
+#         FROM quay.io/giantswarm/crd-installer:0.1.1 AS installer
+#         FROM quay.io/giantswarm/alpine:3.13.5 AS downloader
+#         WORKDIR /tmp/crd-installer
+#         COPY --from=0 /usr/bin/kube-controllers /crd-installer/kube-controllers
+#         COPY --from=installer /scripts /scripts
+#         RUN CALICO_VERSION=$(/crd-installer/kube-controllers -version) && \
+#             /scripts/download-calico-crds.sh $CALICO_VERSION
+#         FROM scratch
+#         COPY --from=downloader /tmp/crd-installer/crds /crds
+#         COPY --from=installer /usr/local/bin/crd-installer /usr/local/bin/crd-installer
+#         CMD ["/usr/local/bin/crd-installer", "-dir", "/crds"]
 - name: quay.io/calico/node
   patterns:
   - pattern: '>= v3.9.5'

--- a/images.yaml
+++ b/images.yaml
@@ -638,7 +638,7 @@
   overrideRepoName: calico-crd-installer
   patterns:
   # Skip v3.19.2 as it's not functional
-  - pattern: '>= v3.15.0 || != v3.19.2'
+  - pattern: '>= v3.15.0, != v3.19.2'
     customImages:
     - dockerfileOptions:
       - |


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C3C7ZQXC1/p1628262522004900 for internal discussion