### PR TITLE
Revert calico-crd-installer version range change (#606)

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -645,8 +645,7 @@
 - name: quay.io/calico/kube-controllers
   overrideRepoName: calico-crd-installer
   patterns:
-  # Skip v3.19.2 as it's not functional
-  - pattern: '>= v3.15.0, != v3.19.2'
+  - pattern: '>= v3.15.0'
     customImages:
     - dockerfileOptions:
       - |


### PR DESCRIPTION
The release and CRDs are now available for 3.19.2: https://github.com/projectcalico/calico/tree/v3.19.2/_includes/charts/calico/crds/kdd

This reverts commit 542081ea5732fca2d0c86de1bf155501ec4e23f2.