### PR TITLE
Add calicoctl

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -641,6 +641,16 @@
 - name: quay.io/calico/cni
   patterns:
   - pattern: '>= v3.9.5'
+- name: quay.io/calico/ctl
+  patterns:
+  - pattern: '>= v3.19.0'
+    customImages:
+    - dockerfileOptions:
+      - |
+        FROM quay.io/giantswarm/alpine:3.13.5
+        COPY --from=1 /calicoctl /calicoctl
+        ENV PATH=$PATH:/
+        ENTRYPOINT ["calicoctl"]
 - name: quay.io/calico/kube-controllers
   patterns:
   - pattern: '>= v3.9.5'


### PR DESCRIPTION
Adding calicoctl for https://github.com/giantswarm/giantswarm/issues/14791. Using alpine as the base image so that we can use the shell (upstream image is FROM scratch).