### PR TITLE
Fix calicoctl

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -649,7 +649,7 @@
     - dockerfileOptions:
       - |
         FROM quay.io/giantswarm/alpine:3.13.5
-        COPY --from=1 /calicoctl /calicoctl
+        COPY --from=0 /calicoctl /calicoctl
         ENV PATH=$PATH:/
         ENTRYPOINT ["calicoctl"]
 - name: quay.io/calico/kube-controllers


### PR DESCRIPTION
Fixing https://github.com/giantswarm/retagger/pull/615 I don't have any way to test this aside from manually copying the `dockerfileOptions` to the end of the upstream dockerfile (which I did) and running `docker build` locally. The upstream dockerfile has two stages so I assumed that `--from` should be 1, but I guess it is considered as a single stage when used this way.