### PR TITLE
add fluent/fluent-bit:1.7.1-systemd-247

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -241,7 +241,7 @@
       - RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update
       - RUN apt-get install -y --no-install-recommends libsystemd-dev/buster-backports
   - sha: befafedde34f12d7756985aae4dc9825a7e2b1287f3d44780cac2038ee2ddb2f
-    tag: '1.7.1-systemd-247'
+    tag: '1.7.1-systemd247'
     customImages:
     - dockerfileOptions:
       - FROM amd64/debian:buster-slim as builder

--- a/images.yaml
+++ b/images.yaml
@@ -240,6 +240,17 @@
     - dockerfileOptions:
       - RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update
       - RUN apt-get install -y --no-install-recommends libsystemd-dev/buster-backports
+  - sha: befafedde34f12d7756985aae4dc9825a7e2b1287f3d44780cac2038ee2ddb2f
+    tag: '1.7.1-systemd-247'
+    customImages:
+    - dockerfileOptions:
+      - FROM amd64/debian:buster-slim as builder
+      - RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
+            apt-get update && \
+            apt-get install -y --no-install-recommends \
+            libsystemd-dev/buster-backports
+      - FROM fluent/fluent-bit:1.7.1-debug
+      - COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 - name: fluent/fluentd-kubernetes-daemonset
   tags:
   - sha: f9fa60dab5e7a6ae4adbe972a2fc22cf7eaa148df74cde4cd7f57e7019260451


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19055

Fix an issue with outadted systemd libraries in fluent-bit upstream image.
Upgrade systemd lib from 241 to 247 using debian backports: https://packages.debian.org/buster-backports/libsystemd-dev