### PR TITLE
Revert "stop retagging kong >= 2.6 as it is broken upstream"

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -627,7 +627,7 @@
     tag: v0.6.0
 - name: kong
   patterns:
-  - pattern: '>= 1.4.3 < 2.6'
+  - pattern: '>= 1.4.3'
 - name: kong/kubernetes-ingress-controller
   overrideRepoName: kong-ingress-controller
   patterns:


### PR DESCRIPTION
This reverts commit 95cc1e760936b41b76430a851d00e0335154db58.