### PR TITLE
retag external-dns from k8s.gcr.io instead from eu.gcr.io/k8s-artifac…

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -203,9 +203,6 @@
     sha: a367cb89efbc2eafcb6df98ce6cfaf8d098928ae23ca2da56a7d2e95fc825c44
   - tag: v1.14.8
     sha: 60a75bd24a4121adf5de16cdad76a52295d33aa8aa7c2945b4a9a1a8d2ac17f0
-- name: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns
-  patterns:
-  - pattern: '>= v0.6.0'
 
 # falco-app images
 - name: falcosecurity/falco
@@ -552,6 +549,9 @@
 - name: k8s.gcr.io/cluster-proportional-autoscaler-amd64
   patterns:
   - pattern: '>= 1.6.0'
+- name: k8s.gcr.io/external-dns/external-dns
+  patterns:
+  - pattern: '>= v0.10.1'
 - name: k8s.gcr.io/hyperkube
   patterns:
   - pattern: '>= v1.15'


### PR DESCRIPTION
but its not there yet, lets wait until https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-external-dns/images.yaml its here