### PR TITLE
Retag kube-state-metrics from k8s.gcr.io rather than quay/coreos

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -546,6 +546,9 @@
 - name: k8s.gcr.io/kube-scheduler
   patterns:
   - pattern: '>= v1.16.8 || >= v1.20.0-0'
+- name: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+  patterns:
+  - pattern: '> v1.9.8'
 - name: k8s.gcr.io/metrics-server/metrics-server
   patterns:
   - pattern: '>= v0.4.2'
@@ -762,9 +765,6 @@
   tags:
   - sha: 7806805c93b20a168d0bbbd25c6a213f00ac58a511c47e8fa6409543528a204e
     tag: v0.11.0-amd64
-- name: k8s.gcr.io/kube-state-metrics/kube-state-metrics
-  patterns:
-  - pattern: '> v1.9.8'
 - name: quay.io/coreos/prometheus-config-reloader
   patterns:
   - pattern: '>= v0.38.1'

--- a/images.yaml
+++ b/images.yaml
@@ -762,9 +762,9 @@
   tags:
   - sha: 7806805c93b20a168d0bbbd25c6a213f00ac58a511c47e8fa6409543528a204e
     tag: v0.11.0-amd64
-- name: quay.io/coreos/kube-state-metrics
+- name: k8s.gcr.io/kube-state-metrics/kube-state-metrics
   patterns:
-  - pattern: '>= v1.9.2'
+  - pattern: '> v1.9.8'
 - name: quay.io/coreos/prometheus-config-reloader
   patterns:
   - pattern: '>= v0.38.1'


### PR DESCRIPTION
we currently retag it from coreos https://github.com/giantswarm/retagger/blob/master/images.yaml#L765 but that image registry is extermely out of date (latest 1 year old) https://quay.io/repository/coreos/kube-state-metrics?tab=tags .

we are still using version 1.9.7 that is unsupported big time

https://github.com/kubernetes/kube-state-metrics#compatibility-matrix

This PR changes the retagger source to use the official one: k8s.gcr.io/kube-state-metrics/kube-state-metrics