### PR TITLE
Fixing repo name

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -148,6 +148,7 @@
   patterns:
   - pattern: '>= 7.67.0'
 - name: cytopia/yamllint
+  overrideRepoName: cytopia-yamllint
   patterns:
   - pattern: '>= 1.9'
 - name: dduportal/bats


### PR DESCRIPTION
Seems we have already hosted `yamllint` repo in quay, so changing retagged one's name.