### PR TITLE
added aws-node-termination-handler

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -50,6 +50,9 @@
 - name: amazon/aws-efs-csi-driver
   patterns:
   - pattern: '>= 1.0.0'
+- name: public.ecr.aws/aws-ec2/aws-node-termination-handler
+  patterns:
+  - pattern: '>= v1.15.0'
 - name: amazon/opendistro-for-elasticsearch
   patterns:
   - pattern: '>= 1.3.0'


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/815

retag the upstream image for handling node termination on aws