### PR TITLE
added k8s-dns-node-cache

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -527,6 +527,9 @@
 - name: k8s.gcr.io/cluster-proportional-autoscaler-amd64
   patterns:
   - pattern: '>= 1.6.0'
+- name: k8s.gcr.io/dns/k8s-dns-node-cache
+  patterns:
+  - pattern: '>= 1.21.1'
 - name: k8s.gcr.io/external-dns/external-dns
   patterns:
   - pattern: '>= v0.10.1'


### PR DESCRIPTION
towards: https://github.com/giantswarm/roadmap/issues/828

add k8s.gcr.io/dns/k8s-dns-node-cache to the retagged images