### PR TITLE
Swap Jiralert tags with patterns

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -1015,7 +1015,7 @@
 - name: quay.io/jiralert/jiralert-linux-amd64
   overrideRepoName: jiralert
   patterns:
-  - pattern: '>= 1.1'
+  - pattern: '>= 1.0'
 - name: quay.io/oauth2-proxy/oauth2-proxy
   patterns:
   - pattern: '>= v7.1.3'

--- a/images.yaml
+++ b/images.yaml
@@ -1014,9 +1014,8 @@
   - pattern: '>= v0.14.2'
 - name: quay.io/jiralert/jiralert-linux-amd64
   overrideRepoName: jiralert
-  tags:
-  - sha: 56477327ee511d4165cb19c5f52e1b2e3abb89a743185e5a5da58bbd695a398b
-    tag: 1.1
+  patterns:
+  - pattern: '>= 1.1'
 - name: quay.io/oauth2-proxy/oauth2-proxy
   patterns:
   - pattern: '>= v7.1.3'


### PR DESCRIPTION
Modifies Jiralert image to use patterns instead:

```yaml
  patterns:
  - pattern: '>= 1.0'
```