### PR TITLE
Include pre-releases for k8s.gcr.io/etcd

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -581,7 +581,7 @@
 - name: k8s.gcr.io/etcd
   overrideRepoName: etcd-k8s
   patterns:
-  - pattern: '>= v3.5.4'
+  - pattern: '>= v3.5.4-0'
 - name: k8s.gcr.io/external-dns/external-dns
   patterns:
   - pattern: '>= v0.10.1'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22454

This is because they have versions like `3.5.4-0` and if it compared to a strict version:

```
{"caller":"github.com/giantswarm/retagger/pkg/retagger/job_pattern.go:137","level":"debug","message":"Image etcd:3.5.4-0 does not fulfill constraint >= v3.5.4 because 3.5.4-0 is a prerelease version and the constraint is only looking for release versions","time":"2022-07-15T13:03:47.629717+00:00"}
```

From: https://github.com/Masterminds/semver#working-with-prerelease-versions

> SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions. For example, >=1.2.3 will skip prereleases when looking at a list of releases while >=1.2.3-0 will evaluate and find prereleases.
The reason for the 0 as a pre-release version in the example comparison is because pre-releases can only contain ASCII alphanumerics and hyphens (along with . separators), per the spec. Sorting happens in ASCII sort order, again per the spec. The lowest character is a 0 in ASCII sort order (see an [ASCII Table](http://www.asciitable.com/))