### PR TITLE
Put k8s.gcr.io/etcd images in giantswarm/etcd but with k8s suffix

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -579,9 +579,10 @@
   patterns:
   - pattern: '>= 1.21.1'
 - name: k8s.gcr.io/etcd
-  overrideRepoName: etcd-k8s
   patterns:
   - pattern: '>= v3.5.4-0'
+    customImages:
+    - tagSuffix: k8s
 - name: k8s.gcr.io/external-dns/external-dns
   patterns:
   - pattern: '>= v0.10.1'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22454

[From @fiunchinho testing](https://gigantic.slack.com/archives/C01BYMF6RN0/p1657903537606039?thread_ts=1657902841.335939&cid=C01BYMF6RN0) we know that `/etcd` will be appended to `repositoryName` setting in `KubeadmControlPlane`. This naming and behaviour is questionable but:

```
PullImage \"docker.io/giantswarm/etcd-k8s/etcd:3.5.4-0\" failed" error="failed to pull and unpack image \"docker.io/giantswarm/etcd-k8s/etcd:3.5.4-0\": failed to resolve reference \"docker.io/giantswarm/etcd-k8s/etcd:3.5.4-0\": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

We already have images pushed from `quay.io/coreos/etcd` defined here: https://github.com/giantswarm/retagger/blob/c72cedbaef8e9ed9fd662c64ae4fb74375df346a/images.yaml#L939-L941

My hope is that with this configuration we can use the same destination (`quay.io/giantswram/etcd`) for two source repositories (`quay.io/coreos/etcd` and `k8s.gcr.io/etcd`) but images the later (`k8s.gcr.io/etcd`) will have `-k8s` suffix added to the tags.