### PR TITLE
Add new variant of flatcar containing envsubst

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -19,6 +19,9 @@
     - tagSuffix: python3
       dockerfileOptions:
       - RUN apk add --no-cache python3 py3-yaml
+    - tagSuffix: envsubst
+      dockerfileOptions:
+      - RUN apk add --no-cache gettext
 - name: alpine/git
   overrideRepoName: alpinegit
   tags:


### PR DESCRIPTION
Since flatcar `3227.2.0` the `envsubst` binary is not present any more.
Since we need this in WCs to substitute values in the kubelet config file, we need a docker image containing the tool

This PR adds a new alpine variant containing `envsubst` (present in the `gettext` alpine package).