### PR TITLE
Do not copy /lib in calico-crd-installer

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -890,7 +890,6 @@
         FROM quay.io/giantswarm/alpine:3.15.0 AS downloader
         WORKDIR /tmp/crd-installer
         COPY --from=0 /usr/bin/kube-controllers /crd-installer/kube-controllers
-        COPY --from=0 /lib/ /lib
         COPY --from=0 /lib64/ /lib64
         COPY --from=installer /scripts /scripts
         RUN CALICO_VERSION=$(/crd-installer/kube-controllers -version) && \


### PR DESCRIPTION
This PR attempts to fix failing retagger runs since calico released https://github.com/projectcalico/calico/releases/tag/v3.24.0 which contains this change https://github.com/projectcalico/calico/pull/6225 which removed copying from `/lib`

I did the same and the image builds correctly on my machine.