### PR TITLE
Add filtering and version extraction pre-validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,10 @@ jobs:
 build_and_retag: &build_and_retag
   jobs:
     - validate
+    - unitTest:
+        filters:
+          branches:
+            ignore: master
     - builde2e:
         filters:
           branches:
@@ -135,6 +139,7 @@ build_and_retag: &build_and_retag
         binary: retagger
         requires:
           - validate
+          - unitTest
     - e2eQuay:
         filters:
           branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,16 @@ jobs:
           paths:
             - ./images.yaml
 
+  unitTest:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - checkout
+      - run:
+          name: unit test
+          command: |
+            go test -v ./...
+
   builde2e:
     machine:
       image: ubuntu-2004:202010-01

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ What the attributes mean:
 - `tags[].customImages[].dockerfileOptions[]`: The list of Dockerfile options, used to override base image
 - `patterns[]`: List of patterns. New tags matching one of these patterns will be automatically retagged.
 - `patterns[].pattern`: Valid semver condition to match tags.
+- `patterns[].filter`: Regex to filter tags before validating semver. If empty, filtering is not done. 
 - `patterns[].customImages[]`: Custom images as explained above.
 
 An image may define both `tags` and `patterns`.
 A `pattern` may also include all optional features of a `tag`, such as a `tagSuffix` or `dockerfileOptions`.
+The `filter` MUST include the `<version>` capture group, e.g.: `(?P<version>.*)-alpine`. This way, the version is extracted from the tag and validated against SemVer as usual.
 
 ## Adding an image
 

--- a/images.yaml
+++ b/images.yaml
@@ -111,7 +111,8 @@
     tag: 0.12
 - name: cloudflare/cloudflared
   patterns:
-  - pattern: '>= 2021.0.0'
+  - pattern: '>= 2022.8.0'
+    filter: '^(?P<version>.*)-amd64'
 - name: coredns/coredns
   tags:
   - sha: 8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a

--- a/integration/test/e2e/e2e_test.go
+++ b/integration/test/e2e/e2e_test.go
@@ -18,7 +18,7 @@ import (
 
 const e2eRepository = "retagger-e2e"
 
-const waitTimeInSecondsBeforeCheckingImagesInRegistry = 15
+const waitTimeInSecondsBeforeCheckingImagesInRegistry = 90
 
 func TestE2e(t *testing.T) {
 	c := registry.Config{

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -21,6 +21,7 @@ type Image struct {
 // and stores some configuration for how to handle this group.
 type TagPattern struct {
 	Pattern      string        `yaml:"pattern"`
+	Filter       string        `yaml:"filter,omitempty"`
 	Tag          string        `yaml:"tag"`
 	CustomImages []CustomImage `yaml:"customImages"`
 }

--- a/pkg/retagger/job_definition.go
+++ b/pkg/retagger/job_definition.go
@@ -14,6 +14,7 @@ type JobDefinition struct {
 	SourceTag     string
 	SourceSha     string
 	SourcePattern string
+	SourceFilter  string
 
 	Options JobOptions
 }
@@ -161,6 +162,8 @@ func fromImageTagPattern(image images.Image, tagPattern images.TagPattern) (JobD
 	j := JobDefinition{
 		SourceImage:   image.Name,
 		SourcePattern: tagPattern.Pattern,
+		SourceFilter:  tagPattern.Filter,
+
 		Options: JobOptions{
 			TagTrimVersionPrefix: image.TagTrimVersionPrefix,
 			OverrideRepoName:     image.OverrideRepoName,

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 type PatternJob struct {
 	logger micrologger.Logger
 
+	SourceFilter  string
 	SourcePattern string
 	Source        Source
 
@@ -28,7 +30,7 @@ type PatternJob struct {
 
 // Compile expands a PatternJob into one or multiple SingleJobs using the given Retagger instance.
 func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
-	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v / %v using pattern %v, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.Options))
+	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v / %v using pattern %v with filter %s, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.SourceFilter, job.Options))
 
 	// Create a reference to the external registry.
 	url := fmt.Sprintf("https://%s", job.Source.RepoPath)
@@ -41,7 +43,7 @@ func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
 	}
 
 	// Find tags which match the pattern.
-	matches, err := job.getExternalTagMatches(externalRegistry, job.Source.FullImageName, job.SourcePattern)
+	matches, err := job.getExternalTagMatches(externalRegistry, job.Source.FullImageName, job.SourcePattern, job.SourceFilter)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -96,7 +98,7 @@ func (job *PatternJob) GetSource() Source {
 }
 
 // getExternalTagMatches searches the given docker registry for tags matching the given pattern.
-func (job *PatternJob) getExternalTagMatches(r *dockerRegistry.Registry, image string, pattern string) ([]string, error) {
+func (job *PatternJob) getExternalTagMatches(r *dockerRegistry.Registry, image string, pattern string, filter string) ([]string, error) {
 	// Make sure our constraint is valid.
 	c, err := semver.NewConstraint(pattern)
 	if err != nil {
@@ -123,11 +125,29 @@ func (job *PatternJob) getExternalTagMatches(r *dockerRegistry.Registry, image s
 		}
 	}
 
+	m, err := regexp.Compile(filter)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	// Find tags matching our configured pattern.
 	var matches []string
 	for _, t := range externalRegistryTags {
 		job.logger.Log("level", "debug", "message", fmt.Sprintf("Checking external tag: %s ", t))
-		v, err := semver.NewVersion(t)
+
+		ts := t
+		if filter != "" {
+			if submatches := m.FindStringSubmatchIndex(t); len(submatches) > 0 {
+				result := []byte{}
+				result = m.ExpandString(result, "$version", t, submatches)
+				ts = string(result)
+			} else {
+				job.logger.Log("level", "debug", "message", fmt.Sprintf("Image %s:%s does not match the filter %s", image, t, filter))
+				continue
+			}
+		}
+
+		v, err := semver.NewVersion(ts)
 		if err != nil { // We do not care if the version is not semver.
 			continue
 		}
@@ -151,6 +171,7 @@ func PatternJobFromJobDefinition(jobDef *JobDefinition, r *Retagger) *PatternJob
 		logger: r.logger,
 
 		SourcePattern: jobDef.SourcePattern,
+		SourceFilter:  jobDef.SourceFilter,
 		Source:        GetSourceForJob(jobDef, r),
 
 		Options: jobDef.Options,

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -30,7 +30,7 @@ type PatternJob struct {
 
 // Compile expands a PatternJob into one or multiple SingleJobs using the given Retagger instance.
 func (job *PatternJob) Compile(r *Retagger) ([]SingleJob, error) {
-	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v / %v using pattern %v with filter %s, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.SourceFilter, job.Options))
+	r.logger.Log("level", "debug", "message", fmt.Sprintf("compiling jobs for image %v / %v using pattern %v, with filter %s, with options %#v", job.Source.RepoPath, job.Source.Image, job.SourcePattern, job.SourceFilter, job.Options))
 
 	// Create a reference to the external registry.
 	url := fmt.Sprintf("https://%s", job.Source.RepoPath)

--- a/pkg/retagger/job_pattern.go
+++ b/pkg/retagger/job_pattern.go
@@ -167,11 +167,10 @@ func (job *PatternJob) findTags(tags []string, c *semver.Constraints, m *regexp.
 }
 
 func filterAndExtract(t string, m *regexp.Regexp) string {
-	ts := t
 	if submatches := m.FindStringSubmatchIndex(t); len(submatches) > 0 {
 		result := []byte{}
 		result = m.ExpandString(result, "$version", t, submatches)
-		ts = string(result)
+		ts := string(result)
 		return ts
 	}
 	return ""

--- a/pkg/retagger/job_pattern_test.go
+++ b/pkg/retagger/job_pattern_test.go
@@ -1,0 +1,103 @@
+package retagger
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/giantswarm/micrologger"
+)
+
+func Test_filterAndExtract(t *testing.T) {
+	tcs := []struct {
+		filter         string
+		tag            string
+		expectedResult string
+	}{
+		{
+			filter:         "(?P<version>.*)",
+			tag:            "1.2.3",
+			expectedResult: "1.2.3",
+		},
+		{
+			filter:         "(?P<version>.*)-alpine",
+			tag:            "1.2.3-alpine",
+			expectedResult: "1.2.3",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.tag, func(t *testing.T) {
+			m, _ := regexp.Compile(tc.filter)
+			result := filterAndExtract(tc.tag, m)
+			if result != tc.expectedResult {
+				t.Errorf("Expected %s, got %s", tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func Test_findTags(t *testing.T) {
+
+	tags := []string{
+		"0.9",
+		"0.9-alpine",
+		"1.0.0",
+		"1.0.0-alpine",
+		"1.1.1",
+		"1.1.1-alpine",
+		"1.2.3",
+		"1.2.3-alpine",
+		"1.2.3-debian",
+	}
+
+	logConfig := micrologger.Config{}
+	logger, _ := micrologger.New(logConfig)
+
+	tcs := []struct {
+		job            PatternJob
+		expectedResult []string
+	}{
+		{
+			job: PatternJob{
+				logger:        logger,
+				SourcePattern: "> 1.0.0",
+				SourceFilter:  "(?P<version>.*)",
+				Source: Source{
+					Image: "nginx",
+				},
+				Options:     JobOptions{},
+				Destination: Destination{},
+			},
+			expectedResult: []string{"1.1.1", "1.2.3"},
+		},
+		{
+			job: PatternJob{
+				logger:        logger,
+				SourcePattern: "> 1.0.0",
+				SourceFilter:  "(?P<version>.*)-alpine",
+				Source: Source{
+					Image: "nginx",
+				},
+				Options:     JobOptions{},
+				Destination: Destination{},
+			},
+			expectedResult: []string{"1.1.1-alpine", "1.2.3-alpine"},
+		},
+	}
+
+	for _, tc := range tcs {
+		testName := fmt.Sprintf("%s/%s/%s", tc.job.Source.Image, tc.job.SourcePattern, tc.job.SourceFilter)
+		t.Run(testName, func(t *testing.T) {
+			m, _ := regexp.Compile(tc.job.SourceFilter)
+			c, _ := semver.NewConstraint(tc.job.SourcePattern)
+
+			result := tc.job.findTags(tags, c, m)
+			if !reflect.DeepEqual(result, tc.expectedResult) {
+				t.Errorf("Expected %s, got %s", tc.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Couldflared added the `-amd64` suffix to all the new images starting from 2022.8.1.

This PR adds support for filtering and version extraction before validating SemVer.
It also adds the proper filter for cloudflared

Towards https://github.com/giantswarm/giantswarm/issues/20258