### PR TITLE
Update gcp-compute-persistent-disk-csi-driver image repo

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -1044,7 +1044,7 @@
 - name: registry.k8s.io/capi-openstack/capi-openstack-controller
   patterns:
   - pattern: '>= 0.4.0'
-- name: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+- name: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
   patterns:
   - pattern: '>= 1.7.0'
 - name: registry.k8s.io/cluster-api-aws/cluster-api-aws-controller


### PR DESCRIPTION
Use the staging repo as the latest versions get pushed much later on `registry.k8s.io/cloud-provider-gcp`.