### PR TITLE
Re enable kyverno image

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -396,9 +396,13 @@
     tag: v3.9-thick-amd64
   - sha: ce4c3a421b0ca97540af911f34858bdd9b06fa5817ba7fa2b3bbb906f9237b46
     tag: v3.9-amd64
-# - name: ghcr.io/kyverno/kyverno
-#   patterns:
-#   - pattern: '>= v1.3.4'
+- name: ghcr.io/kyverno/kyverno
+  tags:
+  - sha: 86577d2e18c1b23b0cc9d76f1f2ee49fea429d4fa7dfbb91585e53ffb5b32dcb
+    tag: v1.8.0
+  - sha: 14c019a58a27355daea7b5e354a5f90e31e6affa18312dccbfc61d4779eb4591
+    tag: v1.8.1
+# Momentarily disable kyvernopre
 # - name: ghcr.io/kyverno/kyvernopre
 #   patterns:
 #   - pattern: '>= v1.7.0'

--- a/images.yaml
+++ b/images.yaml
@@ -402,10 +402,12 @@
     tag: v1.8.0
   - sha: 14c019a58a27355daea7b5e354a5f90e31e6affa18312dccbfc61d4779eb4591
     tag: v1.8.1
-# Momentarily disable kyvernopre
-# - name: ghcr.io/kyverno/kyvernopre
-#   patterns:
-#   - pattern: '>= v1.7.0'
+- name: ghcr.io/kyverno/kyvernopre
+  tags:
+  - sha: 94fd71f37158003f05e422056efeb475e2966cc8cdd980ec452caef3faf81eb8
+    tag: v1.8.0
+  - sha: af22790a7ba24bf48b4c1cea3bb3bac69dd83a2daa122248c3000d575e549949
+    tag: v1.8.1
 # policy-reporter images
 - name: ghcr.io/kyverno/policy-reporter
   patterns:


### PR DESCRIPTION
Re enabling Kyverno images pointing to specific SHA since now Kyverno uses OCI index instead.