### PR TITLE
Install openssl on alpine image for vpa needs

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -995,7 +995,10 @@
   overrideRepoName: vpa-certgen-ci-images
   patterns:
   - pattern: '= v11-alpine'
-
+    customImages:
+    - tagSuffix: openssl
+      dockerfileOptions:
+      - RUN apk --update add openssl
 # Used in strimzi-kafka-operator-app
 - name: quay.io/strimzi/jmxtrans
   overrideRepoName: strimzi-jmxtrans


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1673

For CAPA private environment, we need an alpine image with openssl installed to run `vpa-certgen` job.