### PR TITLE
Delete custom tag on vpa certgen ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,11 +134,11 @@ build_and_retag: &build_and_retag
     - unitTest:
         filters:
           branches:
-            ignore: master
+            ignore: main
     - builde2e:
         filters:
           branches:
-            ignore: master
+            ignore: main
         requires:
           - validate
     - architect/go-build:
@@ -151,27 +151,27 @@ build_and_retag: &build_and_retag
     - e2eQuay:
         filters:
           branches:
-            ignore: master
+            ignore: main
         requires:
           - builde2e
           - go-build
     - copy:
         filters:
           branches:
-            only: master
+            only: main
         requires:
           - validate
     - retagQuay:
         filters:
           branches:
-            only: master
+            only: main
         requires:
           - copy
           - go-build
     - retagAliyun:
         filters:
           branches:
-            only: master
+            only: main
         requires:
           - copy
           - go-build
@@ -188,5 +188,5 @@ workflows:
           cron: "30 21 * * *"
           filters:
             branches:
-              only: master
+              only: main
     <<: *build_and_retag

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For example, at the time of this writing:
 
 ### Execution
 
-Please provide a PR with the change. Once merged into master, CI will execute
+Please provide a PR with the change. Once merged into main, CI will execute
 `retagger` to push any new images.
 
 **Note**: To keep execution speedy, when adding a new version, please remove older versions (tags) that are no longer
@@ -148,7 +148,7 @@ used from the configuration.
 
 - In Quay, a repository must exist for the image before retagger can push an image.
 
-The `retagger` works inside a CI build. On merges to master, the binary is executed. The workflow is to add a new image
+The `retagger` works inside a CI build. On merges to main, the binary is executed. The workflow is to add a new image
 / sha tag pair or pattern in a PR, review it, and then merge. The `retagger` will take care that the image is handled.
 Users will still need to create repositories in the registry.
 

--- a/images.yaml
+++ b/images.yaml
@@ -995,10 +995,6 @@
   overrideRepoName: vpa-certgen-ci-images
   patterns:
   - pattern: '= v11-alpine'
-    customImages:
-    - tagSuffix: openssl
-      dockerfileOptions:
-      - RUN apk --update add openssl
 # Used in strimzi-kafka-operator-app
 - name: quay.io/strimzi/jmxtrans
   overrideRepoName: strimzi-jmxtrans


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1673

To fix the issue on private environment and do not touch on actual installations,  we decided to remove the custom tag on vpa-certgen-ci-images and fixed the issue on `vertical-pod-autoscaler` app.