### PR TITLE
Delete custom tag on vpa-certgen-ci-images

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -995,10 +995,6 @@
   overrideRepoName: vpa-certgen-ci-images
   patterns:
   - pattern: '= v11-alpine'
-    customImages:
-    - tagSuffix: openssl
-      dockerfileOptions:
-      - RUN apk --update add openssl
 # Used in strimzi-kafka-operator-app
 - name: quay.io/strimzi/jmxtrans
   overrideRepoName: strimzi-jmxtrans


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1673

To fix the issue on private environment and do not touch on actual installations,  we decided to remove the custom tag on vpa-certgen-ci-images and fixed the issue on `vertical-pod-autoscaler` app.