### PR TITLE
Update location of azurefile-csi image since the one we currently use has been deprecated

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -643,9 +643,6 @@
   tags:
   - sha: 46ebe46d7d5284455b256c6d0ebaa396cd38b2618cd292e607c447ab5a833311
     tag: 'ciprod06112021'
-- name: mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi
-  patterns:
-  - pattern: '>= v1.12.0'
 - name: mcr.microsoft.com/oss/azure/aad-pod-identity/mic
   patterns:
   - pattern: '>= 1.7.0'
@@ -653,6 +650,9 @@
   patterns:
   - pattern: '>= 1.7.0'
 - name: mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi
+  patterns:
+  - pattern: '>= v1.12.0'
+- name: mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi
   patterns:
   - pattern: '>= v1.12.0'
 - name: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager

--- a/images.yaml
+++ b/images.yaml
@@ -643,7 +643,7 @@
   tags:
   - sha: 46ebe46d7d5284455b256c6d0ebaa396cd38b2618cd292e607c447ab5a833311
     tag: 'ciprod06112021'
-- name: mcr.microsoft.com/k8s/csi/azurefile-csi
+- name: mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi
   patterns:
   - pattern: '>= v1.12.0'
 - name: mcr.microsoft.com/oss/azure/aad-pod-identity/mic


### PR DESCRIPTION
The location we are using was deprecated at the end of june , see https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/1049 

This finding came out of https://github.com/giantswarm/giantswarm/issues/24581

This change **should not affect** existing images in quay since retagger does not overwrite images already present in the registry

Until Version _1.22.0_ the images from deprecated and new repos are built out of different commits, starting from _1.22.0_ they are built out of the same commit but with _different GO Versions_
The current images are built with _1.19_ 


---

```
$ ./compare-azurefile-csi-repos.sh                                                                       
                                                    
==========  Comparing images for azurefile-csi  ==========
➜ GS image: quay.io/giantswarm/azurefile-csi:vXXX
➜ MCR image: mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:vXXX
                                                    
###########                          
➜ Version: 1.19.0                                                                                        
✖ Mismatch
➜ GS:
Commit: 8ea7ec824cd2cd1bf14597f12c043c3dd3575074
Driver: v1.19.0
Golang: go1.17
➜ MCR:
Commit: 891ef9191b80ffe4a73972264274249a546262c8
Driver: v1.19.0
Golang: go1.18.1

###########
➜ Version: 1.20.0
✖ Mismatch
➜ GS:
Commit: dc60aa9f436514d17a12e3ed96a146dd773e67a9
Driver: v1.20.0
Golang: go1.18.3
➜ MCR:
Commit: d37e60c4dbe319f4044bcbff09acce361623e528
Driver: v1.20.0
Golang: go1.18.1

###########
➜ Version: 1.21.0
✖ Mismatch
➜ GS:
Commit: 4822f6897b0a721146a2501c9b26702209e8b016
Driver: v1.21.0
Golang: go1.18.3
➜ MCR:
Commit: f4cc004dc536f4cb27d3b47e3baf84995b0a8409
Driver: v1.21.0
Golang: go1.19

###########
➜ Version: 1.22.0
✔ Git Commit and driver version Match

###########
➜ Version: 1.23.0
✔ Git Commit and driver version Match

###########
➜ Version: 1.24.0
✔ Git Commit and driver version Match


```


