### PR TITLE
Adding custom tag with openssl in vpa-certgen-ci-image

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -997,6 +997,10 @@
   overrideRepoName: vpa-certgen-ci-images
   patterns:
   - pattern: '= v11-alpine'
+    customImages:
+    - tagSuffix: openssl
+      dockerfileOptions:
+      - RUN apk add --no-cache openssl
 # Used in strimzi-kafka-operator-app
 - name: quay.io/strimzi/jmxtrans
   overrideRepoName: strimzi-jmxtrans


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1673

To avoid `apk add openssl` command on runtime in `vpa-certgen` job, we create a custom tag with `openssl` in the docker image.