### PR TITLE
Fix vpa-certgen-ci-images tag with alpine filter

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -996,7 +996,8 @@
 - name: quay.io/reactiveops/ci-images
   overrideRepoName: vpa-certgen-ci-images
   patterns:
-  - pattern: '= v11-alpine'
+  - pattern: '>= v11'
+    filter: '^(?P<version>.*)-alpine'
     customImages:
     - tagSuffix: openssl
       dockerfileOptions:


### PR DESCRIPTION
Fix custom tag filter for `vpa-certgen-ci-images`