### PR TITLE
node-exporter: added vanilla images

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -971,6 +971,7 @@
   tags:
   - sha: d8da0790760c279d961e63aa711fac3fd6a3db237eccea3c8a21239dca64805c
     tag: v0.9.0
+# node-exporter-app < 1.14.0 relies on custom node-exporter images
 - name: quay.io/prometheus/node-exporter
   tags:
   - sha: fc004c4a3d1096d5a0f144b1093daa9257a573ce1fde5a9b8511e59a7080a1bb
@@ -1008,6 +1009,10 @@
       - USER root
       - RUN addgroup -g 1000 -S giantswarm && adduser -u 1000 -S giantswarm -G giantswarm
       - USER giantswarm
+# node-exporter-app >= 1.14.0 just uses vanilla images
+- name: quay.io/prometheus/node-exporter
+  patterns:
+  - pattern: '>= v1.3.0'
 - name: quay.io/pusher/oauth2_proxy
   tags:
   - sha: 1fad3f247a8edeceead03230d833fcb4c3935a3a57b83787690f15f7daa6b59b


### PR DESCRIPTION
Node-exporter:
- retag latest images
- no need customize them, we now rely on vanilla images