### PR TITLE
Only log a warning in case of conflicts since they must be expected with our current configuration

### DIFF
--- a/pkg/retagger/executor.go
+++ b/pkg/retagger/executor.go
@@ -34,8 +34,14 @@ func (r *Retagger) ExecuteJobs() error {
 		r.logger.Log("level", "info", "message", "Retagger is in --dry-run mode. Listing jobs, but not running them.")
 	}
 
-	if err := checkConflicts(r.compiledJobs); err != nil {
-		return err
+	if conflictErrors := checkConflicts(r.compiledJobs); len(conflictErrors) > 0 {
+		// These are warnings since we already had lots of conflicts on purpose in our configuration.
+		// For example, if we choose a fixed SHA for `alpine:3.14` and the upstream tag `3.14` gets updated to a
+		// newer image, it's a conflict and we don't want to fail for such normal use cases.
+		for _, conflictError := range conflictErrors {
+			r.logger.Log("level", "warn", "message", fmt.Sprintf("Found conflict: %s", conflictError))
+
+		}
 	}
 
 	for _, j := range r.compiledJobs {

--- a/pkg/retagger/job_pattern_test.go
+++ b/pkg/retagger/job_pattern_test.go
@@ -221,10 +221,10 @@ func Test_checkConflicts(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		err := checkConflicts(tc.jobs)
-		if err != nil && !tc.hasConflicts {
-			t.Errorf("Case %s: Expected case to show no conflicts, but got an error: %s", tc.description, err)
-		} else if err == nil && tc.hasConflicts {
+		errors := checkConflicts(tc.jobs)
+		if len(errors) > 0 && !tc.hasConflicts {
+			t.Errorf("Case %s: Expected case to show no conflicts, but got an error: %s", tc.description, errors[0])
+		} else if len(errors) == 0 && tc.hasConflicts {
 			t.Errorf("Case %s: Expected case to show conflicts, but got no error", tc.description)
 		}
 	}


### PR DESCRIPTION
This existing config would be a conflict since both write to the destination tag `3.14`:

```
- name: alpine
  tags:
  - sha: 234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0
    tag: 3.14
[...]
  patterns:
  - pattern: '>= 3.13'
[...]
```

Since we have such expected cases, let's turn my new conflict check into warnings. I'm also fine to remove it again if we think it's not helpful.

Fixes the conflict check introduced with https://github.com/giantswarm/retagger/pull/780. Part of https://github.com/giantswarm/roadmap/issues/1722.