### PR TITLE
Address 404 issue on bats images

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -94,8 +94,9 @@
   patterns:
   - pattern: '>= 5'
 - name: bats/bats
-  patterns:
-  - pattern: '>= 1.2.1'
+  tags:
+  - sha: acd28536088c346bc81f1a01d0c4c166d2a244f86ecaa486d92d6edfbf5bd258
+    tag: 1.9.0
 - name: bitnami/kubectl
   patterns:
   - pattern: '>= 1.16'


### PR DESCRIPTION
Blocks: https://github.com/giantswarm/giantswarm/issues/24587

We do have an issue with `retagger` and images that have been migrated to OCI format  

see 
* https://github.com/giantswarm/giantswarm/issues/24014 
* https://github.com/giantswarm/giantswarm/issues/25601
* https://gigantic.slack.com/archives/CLPMFRVU6/p1676307153916429

the `bats` one has transitioned between 1.8.2 and 1.9.0

```
➜  crane manifest bats/bats:1.8.2 |  jq '.manifests[] | select(.platform.architecture == "amd64")|.mediaType'
"application/vnd.docker.distribution.manifest.v2+json"

➜ crane manifest bats/bats:1.9.0 | jq '.manifests[] | select(.platform.architecture == "amd64")|.mediaType'
"application/vnd.oci.image.manifest.v1+json"   

```

Conver the image to be pulled by SHA rather than by pattern

```
➜ crane manifest bats/bats:1.9.0 | jq '.manifests[] | select(.platform.architecture == "amd64")|.digest'    
"sha256:acd28536088c346bc81f1a01d0c4c166d2a244f86ecaa486d92d6edfbf5bd258"   
```
