### PR TITLE
Add entries for CPI&CSI images required by vSphere (CAPV)

### DIFF
--- a/images/customized-images.yaml
+++ b/images/customized-images.yaml
@@ -77,6 +77,15 @@
 - image: cloudflare/cloudflared
   semver: ">= 2022.8.0"
   filter: "^(.+)-amd64$"
+- image: gcr.io/cloud-provider-vsphere/cpi/release/manager
+  semver: ">= v1.26.0"
+  override_repo_name: cpi-vsphere-manager
+- image: gcr.io/cloud-provider-vsphere/csi/release/driver
+  semver: ">= v2.7.1"
+  override_repo_name: csi-vsphere-driver
+- image: gcr.io/cloud-provider-vsphere/csi/release/syncer
+  semver: ">= v2.7.1"
+  override_repo_name: csi-vsphere-syncer
 - image: coredns/coredns
   semver: ">= 1.6.5"
   add_tag_suffix: "giantswarm"

--- a/images/skopeo-gcr-io.yaml
+++ b/images/skopeo-gcr-io.yaml
@@ -12,12 +12,6 @@ gcr.io:
   images-by-semver:
     cadvisor/cadvisor:
       - ">= v0.44.0"
-    cloud-provider-vsphere/cpi/release/manager:
-      - ">= v1.26.0"
-    cloud-provider-vsphere/csi/release/driver:
-      - ">= v2.7.1"
-    cloud-provider-vsphere/csi/release/syncer:
-      - ">= v2.7.1"
     k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:
       - ">= 1.7.0"
     kubebuilder/kube-rbac-proxy:

--- a/images/skopeo-gcr-io.yaml
+++ b/images/skopeo-gcr-io.yaml
@@ -12,6 +12,12 @@ gcr.io:
   images-by-semver:
     cadvisor/cadvisor:
       - ">= v0.44.0"
+    cloud-provider-vsphere/cpi/release/manager:
+      - ">= v1.26.0"
+    cloud-provider-vsphere/csi/release/driver:
+      - ">= v2.7.1"
+    cloud-provider-vsphere/csi/release/syncer:
+      - ">= v2.7.1"
     k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:
       - ">= 1.7.0"
     kubebuilder/kube-rbac-proxy:

--- a/main.go
+++ b/main.go
@@ -213,11 +213,11 @@ func (img *CustomImage) RetagUsingTags() error {
 	if flagSkipExistingTags {
 		quayTags, err := listTags(fmt.Sprintf("%s/%s", quayURL, destinationName))
 		if err != nil {
-			return fmt.Errorf("error getting Quay.io tags: %w", err)
+			logrus.Warnf("error getting Quay.io tags: %w", err)
 		}
 		aliyunTags, err := listTags(fmt.Sprintf("%s/%s", aliyunURL, destinationName))
 		if err != nil {
-			return fmt.Errorf("error getting Aliyun tags: %w", err)
+			logrus.Warnf("error getting Aliyun tags: %w", err)
 		}
 		tags = img.FindMissingTags(tags, quayTags, aliyunTags)
 		logrus.Infof("Found %d missing tags for image %q", len(tags), img.Image)


### PR DESCRIPTION
they are being consumed by https://github.com/giantswarm/cloud-provider-vsphere-app/tree/main/helm/cloud-provider-vsphere/charts

Other images that are referenced from that helm chart above are already being periodically retagged (`sig-storage/csi-provisioner`, `sig-storage/csi-resizer`, `sig-storage/livenessprobe`)