### PR TITLE
Redundant image

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ images.
 
 ## How to add your image to the job
 
-You've come to the right place. Pick one of the below methods.
+You've come to the right place. Pick one of the below methods. For both methods first make sure
+the repository exists in the desired container registry.
 
 ### Plain copy
 

--- a/images/customized-images.yaml
+++ b/images/customized-images.yaml
@@ -179,9 +179,6 @@
 - image: fluxcd/source-controller
   override_repo_name: fluxcd-source-controller
   semver: ">= v0.17.0"
-- image: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  override_repo_name: cloud-provider-vsphere
-  semver: ">= v1.22.6"
 - image: gcr.io/cluster-api-provider-vsphere/release/manager
   override_repo_name: cluster-api-vsphere-controller
   semver: ">= v0.8.1"


### PR DESCRIPTION
In my previous PR (https://github.com/giantswarm/retagger/pull/814) I've added an image that has already been retagged&synced. So I am removing the redundancy here.

Also adding a note to the readme that those repositories need to be created. Otherwise sync fails.