### PR TITLE
bump crd installer to 0.2.0

### DIFF
--- a/images/customized-images.yaml
+++ b/images/customized-images.yaml
@@ -240,7 +240,7 @@
   semver: ">= v3.21.3"
   dockerfile_extras:
     - |
-      FROM quay.io/giantswarm/crd-installer:0.1.2 AS installer
+      FROM quay.io/giantswarm/crd-installer:0.2.0 AS installer
       FROM quay.io/giantswarm/alpine:3.15.0 AS downloader
       WORKDIR /tmp/crd-installer
       COPY --from=0 /usr/bin/kube-controllers /crd-installer/kube-controllers


### PR DESCRIPTION
to fix bug with generating calico-crd-installer images