### PR TITLE
Added go-containerregistry/crane

### DIFF
--- a/images/skopeo-gcr-io.yaml
+++ b/images/skopeo-gcr-io.yaml
@@ -9,6 +9,8 @@ gcr.io:
       - "v1.11"
     spark-operator/spark-operator:
       - "v2.4.0-v1beta1-latest"
+    go-containerregistry/crane:
+      - "debug"
   images-by-semver:
     cadvisor/cadvisor:
       - ">= v0.44.0"


### PR DESCRIPTION
For use in the E2E pipelines to check for new images being published yet.