### PR TITLE
Add special handling of known mutable tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -413,6 +413,12 @@ func (img *CustomImage) FindMissingTags(tags []string, present ...[]string) []st
 			}
 		}
 
+		// We always want to attempt to sync these mutable tags
+		if tag == "latest" || tag == "develop" || tag == "debug" {
+			logrus.Tracef("image %s has a mutable tag (%s) so considering it missing", img.Image, tag)
+			tagIsMissing = true
+		}
+
 		if tagIsMissing {
 			filteredTags = append(filteredTags, tag)
 		}


### PR DESCRIPTION
To ensure that known mutable tags are synced from upstream we add a special handling for `latest`, `debug` and `develop` to always attempt to sync changes from upstream.