### PR TITLE
Added Sonobuoy latest

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -101,6 +101,8 @@ docker.io:
       - "4.0.9"
       - "6.2.1-alpine"
       - "6.2.4-alpine"
+    sonobuoy/sonobuoy:
+      - "latest"
     toniblyx/prowler:
       - "2.2.0"
     weaveworks/watch:


### PR DESCRIPTION
Needed for the conformance tests pipeline to avoid the Docker Hub rate limiting. 

Towards: https://github.com/giantswarm/giantswarm/issues/28015