### PR TITLE
Add semver golang retagging

### DIFF
--- a/images/customized-images.yaml
+++ b/images/customized-images.yaml
@@ -89,6 +89,9 @@
 - image: gcr.io/cloud-provider-vsphere/csi/release/syncer
   semver: ">= v2.7.1"
   override_repo_name: csi-vsphere-syncer
+- image: golang
+  semver: ">= 1.21.1"
+  filter: "(.+)-alpine3.18"
 - image: coredns/coredns
   semver: ">= 1.6.5"
   add_tag_suffix: "giantswarm"

--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -48,6 +48,7 @@ docker.io:
       - "1.18.1-alpine3.15"
       - "1.19.1-alpine3.16"
       - "1.20.6-alpine3.17"
+      # Future `golang` versions are now handled in `customized-images.yaml` to automatically match alpine tags via semver
     golangci/golangci-lint:
       - "v1.23.8"
     instrumenta/conftest:


### PR DESCRIPTION
Support automatic retagging of new Golang images with the alpine variant.
