### PR TITLE
Add k8s-sidecar retagging

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -180,6 +180,8 @@ docker.io:
       - ">= 1.20.0"
     k8scloudprovider/openstack-cloud-controller-manager:
       - ">= 1.20.0"
+    kiwigrid/k8s-sidecar:
+      - ">= 1.24.0"
     kong:
       - ">= 1.4.3"
     mikefarah/yq:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28412 as the latest loki-backend is using this sidecar:

```
k get sts -n loki loki-backend -oyaml | grep sidecar
        image: kiwigrid/k8s-sidecar:1.24.3
```