### PR TITLE
Update Squid proxy image to allow SSH proxying

### DIFF
--- a/images/customized-images.yaml
+++ b/images/customized-images.yaml
@@ -474,9 +474,11 @@
 - image: ubuntu/squid
   sha: 4e1f0204b58779fb89f0281b3ccd4ee19723209d65dbec63bc4b5a07d0509841
   tag_or_pattern: "5.2-22.04_beta"
-  add_tag_suffix: giantswarm_gs1
+  add_tag_suffix: giantswarm_gs2
   dockerfile_extras:
     - RUN sed -i '/^acl SSL_ports port 443/a acl SSL_ports port 6443' /etc/squid/squid.conf
+    - RUN sed -i '/^acl SSL_ports port 443/a acl SSL_ports port 22' /etc/squid/squid.conf
+    - RUN sed -i '/^acl Safe_ports port 443/a acl Safe_ports port 22' /etc/squid/squid.conf
     - RUN sed -i 's/http_access deny CONNECT/#http_access deny CONNECT/g' /etc/squid/squid.conf
     - RUN chmod a+rwx /run && chmod a+rwx /var/log/squid && chmod a+rwx /var/spool/squid
     - USER proxy


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26154

This PR enables support for proxying ssh over VPN via the squid. 

@calvix was there a reason for using the specific sha? According to Docker Hub the current sha for `5.2-22.04_beta` is `b37e34479db87f2f561e89747d09db69899b485fb549892acd3af7485e3ba102`