### PR TITLE
Fix regex to support sha references

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	temporaryWorkingDir     = path.Join(os.TempDir(), "retagger")
-	skopeoSyncOutputPattern = regexp.MustCompile(`Would have copied image.*?from="docker://(.*?):(.*?)".*`)
+	skopeoSyncOutputPattern = regexp.MustCompile(`Would have copied image.*?from="docker://(.*?)[@:](.*?)".*`)
 
 	flagLogLevel         string
 	flagExecutorCount    int


### PR DESCRIPTION
The regex only previously supported standard tags but the docs suggest that `@sha256:....` references can also be used (and are supported by skopeo).