### PR TITLE
pull latest nginx-unprivileged image

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -78,6 +78,7 @@ docker.io:
       - "1.23-alpine"
     nginxinc/nginx-unprivileged:
       - "1.23-alpine"
+      - "1.24-alpine"
     ns1labs/flame:
       - "0.11.0"
     peaceiris/hugo:


### PR DESCRIPTION
Towards https://github.com/giantswarm/loki-app/pull/222
We need the latest `nginx-unprivileged` image for the latest loki version