### PR TITLE
Update Azure images tags

### DIFF
--- a/images/skopeo-mcr-microsoft-com.yaml
+++ b/images/skopeo-mcr-microsoft-com.yaml
@@ -15,4 +15,4 @@ mcr.microsoft.com:
     oss/kubernetes/azure-cloud-controller-manager:
       - ">= v1.24.5"
     oss/kubernetes/azure-cloud-node-manager:
-      - ">= v1.1.8"
+      - ">= v1.24.5"

--- a/images/skopeo-mcr-microsoft-com.yaml
+++ b/images/skopeo-mcr-microsoft-com.yaml
@@ -7,7 +7,7 @@ mcr.microsoft.com:
     oss/azure/aad-pod-identity/mic:
       - ">= 1.8.10"
     oss/azure/aad-pod-identity/nmi:
-      - ">= 1.7.0"
+      - ">= 1.8.10"
     oss/kubernetes-csi/azuredisk-csi:
       - ">= v1.12.0"
     oss/kubernetes-csi/azurefile-csi:

--- a/images/skopeo-mcr-microsoft-com.yaml
+++ b/images/skopeo-mcr-microsoft-com.yaml
@@ -9,9 +9,9 @@ mcr.microsoft.com:
     oss/azure/aad-pod-identity/nmi:
       - ">= 1.8.10"
     oss/kubernetes-csi/azuredisk-csi:
-      - ">= v1.12.0"
+      - ">= v1.25.0"
     oss/kubernetes-csi/azurefile-csi:
-      - ">= v1.12.0"
+      - ">= v1.25.0"
     oss/kubernetes/azure-cloud-controller-manager:
       - ">= v1.24.5"
     oss/kubernetes/azure-cloud-node-manager:

--- a/images/skopeo-mcr-microsoft-com.yaml
+++ b/images/skopeo-mcr-microsoft-com.yaml
@@ -5,7 +5,7 @@ mcr.microsoft.com:
       - "ciprod06112021"
   images-by-semver:
     oss/azure/aad-pod-identity/mic:
-      - ">= 1.7.0"
+      - ">= 1.8.10"
     oss/azure/aad-pod-identity/nmi:
       - ">= 1.7.0"
     oss/kubernetes-csi/azuredisk-csi:

--- a/images/skopeo-mcr-microsoft-com.yaml
+++ b/images/skopeo-mcr-microsoft-com.yaml
@@ -13,6 +13,6 @@ mcr.microsoft.com:
     oss/kubernetes-csi/azurefile-csi:
       - ">= v1.12.0"
     oss/kubernetes/azure-cloud-controller-manager:
-      - ">= v1.1.8"
+      - ">= v1.24.5"
     oss/kubernetes/azure-cloud-node-manager:
       - ">= v1.1.8"


### PR DESCRIPTION
- [azure-ad-pod-identity-app](https://github.com/giantswarm/azure-ad-pod-identity-app) - capz collection uses 0.15.0 which uses v1.8.10
- azure-cloud-controller-manager - in vintage 19.0.1 1.24.6-gs1 is used with `v1.24.5` - CAPZ collection uses latest
- azure-cloud-node-manager - same as azure-cloud-controller-manager
- azuredisk-csi-driver-app - adjusted to 19.0.1 for azure -> CAPZ uses latest
- azurefile-csi-driver-app  - adjusted to 19.0.1 for azure -> CAPZ uses latest

