### PR TITLE
Renovate config: add group for [open]containers packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,8 +1,17 @@
 {
-  "extends": [
+  extends: [
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
     // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
     "github>giantswarm/renovate-presets:lang-go.json5",
+  ],
+  packageRules: [
+    {
+      groupName: "[open]containers",
+      matchPackagePrefixes: [
+        "github.com/containers/",
+        "github.com/opencontainers/",
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Renovate tries upgrading some dependencies individually, but it seems they have to be upgraded in concert.

Current PRs:

- https://github.com/giantswarm/retagger/pull/918
- https://github.com/giantswarm/retagger/pull/916
- https://github.com/giantswarm/retagger/pull/914
- https://github.com/giantswarm/retagger/pull/905

This PR attempts to group them together.