### PR TITLE
Disable Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
-    "github>giantswarm/renovate-presets:default.json5",
-    // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
-    "github>giantswarm/renovate-presets:lang-go.json5",
-  ],
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,3 @@
+{
+    enabled: false,
+}


### PR DESCRIPTION
CI runs for retagger are quite expensive due to layer caching and due to the long duration of job runs.

To limit our cost, we are disabling dependency updates by Renovate.