### PR TITLE
Phoenix retagger update v3 - grand finale

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -224,6 +224,6 @@ docker.io:
     squareup/ghostunnel:
       - ">= v1.5.2"
     vault:
-      - ">= v1.2.0"
+      - ">= v1.5.4"
     velero/velero:
       - ">= v1.4.3"

--- a/images/skopeo-gcr-io.yaml
+++ b/images/skopeo-gcr-io.yaml
@@ -17,6 +17,6 @@ gcr.io:
     cadvisor/cadvisor:
       - ">= v0.44.0"
     k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:
-      - "v1.8.0"
+      - "1.8.0"
     kubebuilder/kube-rbac-proxy:
       - ">= v0.4.1"

--- a/images/skopeo-gcr-io.yaml
+++ b/images/skopeo-gcr-io.yaml
@@ -17,6 +17,6 @@ gcr.io:
     cadvisor/cadvisor:
       - ">= v0.44.0"
     k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:
-      - ">= 1.7.0"
+      - "v1.8.0"
     kubebuilder/kube-rbac-proxy:
       - ">= v0.4.1"

--- a/images/skopeo-mcr-microsoft-com.yaml
+++ b/images/skopeo-mcr-microsoft-com.yaml
@@ -1,8 +1,5 @@
 # Docs: https://github.com/kubasobon/skopeo/blob/main/docs/skopeo-sync.1.md#yaml-file-content-used-source-for---src-yaml
 mcr.microsoft.com:
-  images:
-    azuremonitor/containerinsights/ciprod:
-      - "ciprod06112021"
   images-by-semver:
     oss/azure/aad-pod-identity/mic:
       - ">= 1.8.10"

--- a/images/skopeo-quay-io.yaml
+++ b/images/skopeo-quay-io.yaml
@@ -100,4 +100,4 @@ quay.io:
     thanos/thanos:
       - ">= v0.17.2"
     uswitch/kiam:
-      - ">= v4.0"
+      - ">= v4.2.0"


### PR DESCRIPTION
- pining gcp compute to latest used
- kiam - oldest release uses 4.2.0
- removing ciprod - archived
- Vault - latest release from April uses 1.5.4 - can we use that one @whites11 ?

