### PR TITLE
Move golang to alpine 3.19

### DIFF
--- a/images/customized-images.yaml
+++ b/images/customized-images.yaml
@@ -98,8 +98,8 @@
   semver: ">= v2.7.1"
   override_repo_name: csi-vsphere-syncer
 - image: golang
-  semver: ">= 1.21.1"
-  filter: "(.+)-alpine3.18"
+  semver: ">= 1.21.6"
+  filter: "(.+)-alpine3.19"
 - image: ghcr.io/linkerd/cni-plugin
   override_repo_name: linkerd2-cni-plugin
   semver: ">= v1.1.1"


### PR DESCRIPTION
The goal of this PR is to enable fetching of `golang:1.21.6-alpine3.19`. Currently we are pinned to Alpine 3.18.