### PR TITLE
Remove spark-operator

### DIFF
--- a/images/skopeo-gcr-io.yaml
+++ b/images/skopeo-gcr-io.yaml
@@ -7,8 +7,6 @@ gcr.io:
       - "v3.1.0"
     heptio-images/kube-conformance:
       - "v1.11"
-    spark-operator/spark-operator:
-      - "v2.4.0-v1beta1-latest"
     go-containerregistry/crane:
       - "debug"
     tekton-releases/dogfooding/tkn:


### PR DESCRIPTION
The source image or tag no longer exists, as can be seen in 

https://app.circleci.com/pipelines/github/giantswarm/retagger/3203/workflows/502f2fe3-bff8-43aa-9336-2b0b3d62280c/jobs/62569

Also it seems like all spark related repositories by Giant Swarm are no longer miantained (now archived).