### PR TITLE
Add giantswarm/staticjscms-hugo-standalone

### DIFF
--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -15,6 +15,8 @@ ghcr.io:
       - ">= 0.16.1"
     external-secrets/external-secrets:
       - ">= v0.7.0"
+    giantswarm/staticjscms-hugo-standalone:
+      - ">= v0.0.1"
     kedacore/keda-admission-webhooks:
       - ">= 2.10.1"
     kedacore/keda:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29451

### Summary

We can't currently make `ghcr.io` images (GitHub calls them packages) public, because it's disabled in organization settings (this seems to make sense).

However, I need an image to be publicly accessible for devs local machines (ease of use).

This PR adds it to retagger.


### Note

Changing the workflow to push to quay.io/docker.io directly may happen later.