### PR TITLE
Move aws-load-balancer-controller image to new registry

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -118,8 +118,6 @@ docker.io:
       - ">= 3.11"
     amazon/amazon-eks-pod-identity-webhook:
       - ">= v0.3.0"
-    amazon/aws-alb-ingress-controller:
-      - ">= 2.4.1"
     amazon/aws-efs-csi-driver:
       - ">= 1.0.0"
     aquasec/kube-bench:

--- a/images/skopeo-public-ecr-aws.yaml
+++ b/images/skopeo-public-ecr-aws.yaml
@@ -4,6 +4,8 @@ public.ecr.aws:
     aws-ec2/aws-node-termination-handler:
       - "v1.17.2"
   images-by-semver:
+    eks/aws-load-balancer-controller:
+      - ">= 2.6.1"
     gravitational/teleport:
       - ">= 14.1.1"
     gravitational/teleport-distroless:


### PR DESCRIPTION
New versions of the image are on the public.ecr.aws registry