### PR TITLE
Add validation for skopeo files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,13 @@ jobs:
              giantswarm/yamllint \
              -c .yamllint \
              images/*.yaml
+      - run:
+          name: Run skopeo YAML files through 'skopeo sync --dry-run' for validation
+          command: |
+            for file in images/skopeo-*.yaml; do
+              # The target does not matter here, so we use the non-existing `dummy.example.com/namespace/`.
+              skopeo sync --dry-run --src yaml $file --dest docker dummy.example.com/namespace/
+            done
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,6 @@ build_and_retag: &build_and_retag
             executor_id: [0, 1, 2, 3, 4]
 
 workflows:
-  version: 2
   build_retag:
     <<: *build_and_retag
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  architect: giantswarm/architect@4.27.0
 
 jobs:
   validate:


### PR DESCRIPTION
Context: https://github.com/giantswarm/giantswarm/issues/28543

So far we don't validate skopeo YAML files in CI. This allows to introduce schema errors without noticing in a PR.

This PR adds a `skopeo sync --dry-run` call for each YAML file starting with `skopeo-`. 