### PR TITLE
Pull nginxinc/nginx-unprivileged from GitHub instead of Docker Hub

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -198,4 +198,3 @@ docker.io:
   images-by-tag-regex:
     alpine: ^3\.[123][0-9]\.[0-9]+$
     nginx: ^1\.2[3-9]-alpine$
-    nginxinc/nginx-unprivileged: ^1\.2[3-9]-alpine$

--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -52,3 +52,5 @@ ghcr.io:
       - ">= 0.74"
     slok/sloth:
       - ">= v0.11.0"
+  images-by-tag-regex:
+    nginxinc/nginx-unprivileged: ^1\.2[3-9]-alpine$


### PR DESCRIPTION
The image is[ officially published on ghcr.io, too](https://github.com/orgs/nginxinc/packages?repo_name=docker-nginx-unprivileged). So we use this opportunity to reduce our number of Docker Hub pulls.