### PR TITLE
correct ipam-in-cluster tag

### DIFF
--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -4,8 +4,6 @@ ghcr.io:
     k8snetworkplumbingwg/multus-cni:
       - "v3.9-thick-amd64"
       - "v3.9-amd64"
-    k8s-staging-capi-ipam-ic/cluster-api-ipam-provider-in-cluster:
-      - "v0.1.0-rc.0"
   images-by-semver:
     aquasecurity/node-collector:
       - ">= 0.0.6"

--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -5,8 +5,7 @@ ghcr.io:
       - "v3.9-thick-amd64"
       - "v3.9-amd64"
     k8s-staging-capi-ipam-ic/cluster-api-ipam-provider-in-cluster:
-      - "v0.1.0-alpha.2"
-      - "v0.1.0-alpha.3"
+      - "v0.1.0-rc.0"
   images-by-semver:
     aquasecurity/node-collector:
       - ">= 0.0.6"

--- a/images/skopeo-quay-io.yaml
+++ b/images/skopeo-quay-io.yaml
@@ -48,7 +48,7 @@ quay.io:
     cilium/hubble-ui-backend:
       - ">= v0.8.5"
     cilium/cilium-envoy:
-      - ">=v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9"
+      - ">= v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9"
     coreos/etcd:
       - ">= v3.3"
     dexidp/dex:

--- a/images/skopeo-registry-k8s-io.yaml
+++ b/images/skopeo-registry-k8s-io.yaml
@@ -11,6 +11,8 @@ registry.k8s.io:
       - ">= 0.8.0"
     autoscaling/vpa-updater:
       - ">= 0.8.0"
+    capi-ipam-ic/cluster-api-ipam-in-cluster-controller:
+      - ">= v0.1.0"
     capi-openstack/capi-openstack-controller:
       - ">= 0.4.0"
     cluster-api-azure/cluster-api-azure-controller:


### PR DESCRIPTION
following on from #946, it seems that the alpha tags no longer exist so we need to use a newer image.

available tags are listed here https://console.cloud.google.com/gcr/images/k8s-staging-capi-ipam-ic/GLOBAL/cluster-api-ipam-provider-in-cluster?pli=1
