### PR TITLE
Make static skopeo binary available in our container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,6 @@ jobs:
                 grep "level=error" dry-run.log
                 exit 1
             fi
-            
-
-  build-go:
-    machine:
-      image: ubuntu-2204:2024.01.2
-    steps:
-      - checkout
-      - run:
-          name: Build retagger binary
-          command: |
-            CGO_ENABLED=0 GOOS=linux go build -ldflags "$(cat .ldflags)" -o retagger .
-      - persist_to_workspace:
-          root: .
-          paths:
-            - retagger
 
   build-and-push-docker:
     machine:
@@ -80,15 +65,15 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Build Docker image
+          name: Build container image
           command: |
             docker build -t "<<parameters.registry>>/giantswarm/retagger:<<parameters.tag>>" .
       - run:
-          name: Authenticate to Docker registry
+          name: Authenticate to registry
           command: |
             docker login -u "<<parameters.username>>" -p "<<parameters.password>>" "<<parameters.registry>>"
       - run:
-          name: Push Docker image
+          name: Push container image
           command: |
             echo "Pushing tag '<<parameters.tag>>' to <<parameters.registry>>..."
             docker push "<<parameters.registry>>/giantswarm/retagger:<<parameters.tag>>"
@@ -260,14 +245,6 @@ build_and_retag: &build_and_retag
         name: validate-skopeo
         requires:
           - validate-images-yaml
-    - build-go:
-        context: architect
-        name: build-go
-        requires:
-          - validate-skopeo
-        filters:
-          tags:
-            only: /^v.*/
     - build-and-push-docker:
         context: architect
         name: build-and-push-docker
@@ -276,7 +253,7 @@ build_and_retag: &build_and_retag
         registry: "quay.io"
         tag: ${CIRCLE_TAG:-$CIRCLE_SHA1}
         requires:
-          - build-go
+          - validate-skopeo
     - filter-skopeo-tags:
         context: architect
         name: filter-skopeo-docker-io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM gsoci.azurecr.io/giantswarm/skopeo:v1.15.0@sha256:85fc31993df6f0c8bbb553f2f105c12056ea846c133f341158c21d80f44312a9 AS skopeo-upstream
+FROM gsoci.azurecr.io/giantswarm/golang:1.22.1-alpine3.19 as builder
 
-FROM cimg/go:1.21
-USER root
-COPY --from=skopeo-upstream /etc/containers/* /etc/containers/
-COPY --from=skopeo-upstream /usr/share/containers/* /usr/share/containers/
-COPY --from=skopeo-upstream /var/lib/containers/* /var/lib/containers/
-COPY --from=skopeo-upstream /usr/bin/skopeo /usr/bin/
-RUN mkdir -p /run/containers && \
-    chown -R circleci:circleci /run/containers
-COPY retagger retagger
-USER circleci
+# Build a static skopeo binary
+ARG SKOPEO_VERSION=v1.15.0
+RUN apk add --no-cache git make bash
+WORKDIR /build
+RUN git clone --branch ${SKOPEO_VERSION} --depth 1 https://github.com/containers/skopeo.git
+WORKDIR /build/skopeo
+RUN BUILDTAGS=containers_image_openpgp DISABLE_CGO=1 CGO_ENABLED=0 make bin/skopeo
+
+# Build retagger binary
+WORKDIR /build/retagger
+COPY main.go go.mod go.sum /build/retagger/
+RUN CGO_ENABLED=0 go build -o retagger .
+
+# Add both binraries to a fresh image
+FROM gsoci.azurecr.io/giantswarm/alpine:3.19
+COPY --from=builder /build/skopeo/bin/skopeo /usr/local/bin/skopeo
+COPY --from=builder /build/retagger/retagger /usr/local/bin/retagger
+
+ENTRYPOINT ["retagger"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM gsoci.azurecr.io/giantswarm/golang:1.22.1-alpine3.19 as builder
+ARG ALPINE_VERSION=3.19
+ARG GO_VERSION=1.22.1
+
+FROM gsoci.azurecr.io/giantswarm/golang:${GO_VERSION}-alpine${ALPINE_VERSION} as builder
 
 # Build a static skopeo binary
 ARG SKOPEO_VERSION=v1.15.0
@@ -13,8 +16,8 @@ WORKDIR /build/retagger
 COPY main.go go.mod go.sum /build/retagger/
 RUN CGO_ENABLED=0 go build -o retagger .
 
-# Add both binraries to a fresh image
-FROM gsoci.azurecr.io/giantswarm/alpine:3.19
+# Add both binaries to a fresh image
+FROM gsoci.azurecr.io/giantswarm/alpine:${ALPINE_VERSION}
 COPY --from=builder /build/skopeo/bin/skopeo /usr/local/bin/skopeo
 COPY --from=builder /build/retagger/retagger /usr/local/bin/retagger
 


### PR DESCRIPTION
Previously we tried copying the skopeo binary from a container. However, since it is dynamically linked against system libraries, and these libraries were not portable, this approach failed.

[Error](https://app.circleci.com/pipelines/github/giantswarm/retagger/3412/workflows/d5fa7b11-ba82-45f6-a121-102c9da9cef7/jobs/67936):

```
skopeo: error while loading shared libraries: libgpgme.so.11: cannot open shared object file: No such file or directory
```

Unfortunately, skopeo does not provide binaries as part of their releases. They provide an alpine package, but it's lagging behind. We need v1.15, but the Alpine package is at v1.14.

With this PR we are building our own static skopeo binary to have it available in the same container image that provides retagger.

This binary does not provide GPG functions, which (as I assume) we don't need anyway.