### PR TITLE
Add kong-gateway 3.6.1.3-debian

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -80,6 +80,7 @@ docker.io:
       - "3.5.0.1-debian"
       - "3.5.0.2-debian"
       - "3.5.0.3-debian"
+      - "3.6.1.3-debian"
     looztra/kubesplit:
       - "0.3.2-dd13538"
     madnight/alpine-wkhtmltopdf-builder:


### PR DESCRIPTION
This PR adds kong-gateway 3.6.1.3-debian required for new kong-app release