### PR TITLE
Add vcd cpi and csi images

### DIFF
--- a/images/skopeo-projects-registry-vmware-com.yaml
+++ b/images/skopeo-projects-registry-vmware-com.yaml
@@ -1,0 +1,5 @@
+# Docs: https://github.com/kubasobon/skopeo/blob/main/docs/skopeo-sync.1.md#yaml-file-content-used-source-for---src-yaml
+projects.registry.vmware.com:
+  images-by-semver:
+    vmware-cloud-director/cloud-provider-for-cloud-director: ">= v1.4.0"
+    vmware-cloud-director/cloud-director-named-disk-csi-driver: ">= 1.4.0"


### PR DESCRIPTION
We can now consume upstream images in the [VCD cloud provider app](https://github.com/giantswarm/cloud-provider-cloud-director-app/blob/main/helm/cloud-provider-cloud-director/values.yaml) since our changes were merged.