### PR TITLE
Fix retry errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -276,7 +275,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -287,7 +285,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -298,7 +295,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -309,7 +305,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -320,7 +315,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -331,7 +325,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -342,7 +335,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -353,7 +345,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -364,7 +355,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - retag-registry:
@@ -465,7 +455,6 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
-              - fix-retries # TODO: remove before merging
         matrix:
           parameters:
             # i in range(executor_count)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
   validate:
     machine:
       image: ubuntu-2204:2024.01.2
-    shell: bash
     steps:
       - checkout
       - run:
@@ -83,6 +82,7 @@ jobs:
     docker:
       - image: quay.io/giantswarm/retagger:${CIRCLE_TAG:-$CIRCLE_SHA1}
     resource_class: small
+    shell: /bin/bash
     parameters:
       filepath:
         type: string
@@ -132,6 +132,7 @@ jobs:
     docker:
       - image: quay.io/giantswarm/retagger:${CIRCLE_TAG:-$CIRCLE_SHA1}
     resource_class: small
+    shell: /bin/bash
     parameters:
       username:
         type: string
@@ -171,6 +172,7 @@ jobs:
     docker:
       - image: quay.io/giantswarm/retagger:${CIRCLE_TAG:-$CIRCLE_SHA1}
     resource_class: small
+    shell: /bin/bash
     parameters:
       log_level:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -275,6 +276,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -285,6 +287,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -295,6 +298,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -305,6 +309,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -315,6 +320,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -325,6 +331,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -335,6 +342,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -345,6 +353,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - filter-skopeo-tags:
@@ -355,6 +364,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         requires:
           - build-and-push-docker
     - retag-registry:
@@ -455,6 +465,7 @@ build_and_retag: &build_and_retag
           branches:
             only:
               - main
+              - fix-retries # TODO: remove before merging
         matrix:
           parameters:
             # i in range(executor_count)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
   validate:
     machine:
       image: ubuntu-2204:2024.01.2
+    shell: bash
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ FROM gsoci.azurecr.io/giantswarm/skopeo:v1.15.0 as skopeo
 
 # Add all binaries to a fresh image
 FROM gsoci.azurecr.io/giantswarm/alpine:${ALPINE_VERSION}
+
+# We need bash for CircleCI script execution
+RUN apk add --no-cache bash
+
 COPY --from=builder /build/skopeo/bin/skopeo /usr/local/bin/skopeo
 COPY --from=builder /build/retagger/retagger /usr/local/bin/retagger
 COPY --from=builder /build/docker/docker/docker /usr/local/bin/docker


### PR DESCRIPTION
We see different shell scripting errors resulting in retries for `docker login` not working.

The errors indicate that, contrary to our expectations, the step commands are executed using `/bin/sh` instead of bash.