### PR TITLE
Add vsphere cpi

### DIFF
--- a/images/skopeo-registry-k8s-io.yaml
+++ b/images/skopeo-registry-k8s-io.yaml
@@ -8,6 +8,7 @@ registry.k8s.io:
     autoscaling/vpa-updater: ">= 0.8.0"
     capi-ipam-ic/cluster-api-ipam-in-cluster-controller: ">= v0.1.0"
     capi-openstack/capi-openstack-controller: ">= 0.4.0"
+    cloud-pv-vsphere/cloud-provider-vsphere: ">= v1.28.0"
     cluster-api-azure/cluster-api-azure-controller: ">= v0.5.0"
     cluster-api-gcp/cluster-api-gcp-controller: ">= v1.0.2"
     cluster-proportional-autoscaler-amd64: ">= 1.6.0"


### PR DESCRIPTION
> As part of the overall Kubernetes project image registry migration, starting with the v1.30.1 release, the cloud-provider-vsphere images will be hosted exclusively on the community-owned registry.k8s.io registry. These images will no longer be available on the previous gcr.io/cloud-provider-vsphere/release registry.
>
> Additionally, images for the following versions of cloud-provider-vsphere have already been migrated to registry.k8s.io:
>
> registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.28.0
> registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.29.0

https://github.com/kubernetes/cloud-provider-vsphere?tab=readme-ov-file#warning-kubernetes-image-registry-migration-for-cloud-provider-vsphere