### PR TITLE
Add falcosecurity/k8s-metacollector

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -158,6 +158,7 @@ docker.io:
     falcosecurity/falco-exporter: ">= v0.8.3"
     falcosecurity/falco-no-driver: ">= 0.36.1"
     falcosecurity/falcosidekick: ">= 2.28.0"
+    falcosecurity/k8s-metacollector: ">= 0.1.1"
     fluent/fluent-bit: ">= 1.7.1"
     golang: ">= 1.19.0"
     grafana/alloy: ">= v1.2.0"


### PR DESCRIPTION
Newer Falco versions aren't capable of collecting k8s-meta information themselves anymore and require an external collector. 
Falco promises performance improvements.