### PR TITLE
Add opensearch and traefik

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -182,6 +182,7 @@ docker.io:
     mikefarah/yq: ">= 4.31.2"
     mintel/dex-k8s-authenticator: ">= 1.4.0"
     openpolicyagent/conftest: ">= v0.25.0"
+    opensearchproject/opensearch: ">= 2.16.0"
     prom/blackbox-exporter: ">= v0.23.0"
     prom/prometheus: ">= 2.41.0"
     # Used in akv2k8s

--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -187,6 +187,7 @@ docker.io:
     # Used in akv2k8s
     spvest/azure-keyvault-controller: ">= 1.3.0"
     spvest/azure-keyvault-webhook: ">= 1.3.0"
+    traefik: ">= v3.1"
     vault: ">= v1.5.4"
     velero/velero: ">= v1.4.3"
     zricethezav/gitleaks: ">=v7.4.0"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26502

This adds traefik, which I intend to use as a reverse proxy for our docs and search setup, and OpenSearch, which will be our search engine going forward.