### PR TITLE
Add upbound official images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,8 @@ jobs:
       executor_id:
         type: integer
         default: 0
+      filename:
+        type: string
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -564,6 +566,11 @@ build_and_retag: &build_and_retag
               - main
         matrix:
           parameters:
+            filename:
+              - images/renamed-images.yaml
+              - images/renamed-upbound-aws.yaml
+              - images/renamed-upbound-azure.yaml
+              - images/renamed-upbound-gcp.yaml
             # i in range(executor_count)
             executor_id: [0, 1, 2, 3, 4]
 

--- a/images/renamed-upbound-aws.yaml
+++ b/images/renamed-upbound-aws.yaml
@@ -1,0 +1,501 @@
+- image: xpkg.upbound.io/upbound/provider-family-aws
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-family-aws
+- image: xpkg.upbound.io/upbound/provider-aws-elbv2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-elbv2
+- image: xpkg.upbound.io/upbound/provider-aws-devicefarm
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-devicefarm
+- image: xpkg.upbound.io/upbound/provider-aws-servicediscovery
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-servicediscovery
+- image: xpkg.upbound.io/upbound/provider-aws-cloudwatch
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudwatch
+- image: xpkg.upbound.io/upbound/provider-aws-acmpca
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-acmpca
+- image: xpkg.upbound.io/upbound/provider-aws-appautoscaling
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appautoscaling
+- image: xpkg.upbound.io/upbound/provider-aws-rolesanywhere
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-rolesanywhere
+- image: xpkg.upbound.io/upbound/provider-aws-cloudformation
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudformation
+- image: xpkg.upbound.io/upbound/provider-aws-dlm
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-dlm
+- image: xpkg.upbound.io/upbound/provider-aws-schemas
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-schemas
+- image: xpkg.upbound.io/upbound/provider-aws-cur
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cur
+- image: xpkg.upbound.io/upbound/provider-aws-cognitoidp
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cognitoidp
+- image: xpkg.upbound.io/upbound/provider-aws-rum
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-rum
+- image: xpkg.upbound.io/upbound/provider-aws-kendra
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kendra
+- image: xpkg.upbound.io/upbound/provider-aws-mediapackage
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-mediapackage
+- image: xpkg.upbound.io/upbound/provider-aws-quicksight
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-quicksight
+- image: xpkg.upbound.io/upbound/provider-aws-sns
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-sns
+- image: xpkg.upbound.io/upbound/provider-aws-docdb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-docdb
+- image: xpkg.upbound.io/upbound/provider-aws-workspaces
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-workspaces
+- image: xpkg.upbound.io/upbound/provider-aws-applicationinsights
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-applicationinsights
+- image: xpkg.upbound.io/upbound/provider-aws-opsworks
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-opsworks
+- image: xpkg.upbound.io/upbound/provider-aws-ce
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ce
+- image: xpkg.upbound.io/upbound/provider-aws-budgets
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-budgets
+- image: xpkg.upbound.io/upbound/provider-aws-configservice
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-configservice
+- image: xpkg.upbound.io/upbound/provider-aws-codecommit
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-codecommit
+- image: xpkg.upbound.io/upbound/provider-aws-route53resolver
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-route53resolver
+- image: xpkg.upbound.io/upbound/provider-aws-neptune
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-neptune
+- image: xpkg.upbound.io/upbound/provider-aws-swf
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-swf
+- image: xpkg.upbound.io/upbound/provider-aws-ses
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ses
+- image: xpkg.upbound.io/upbound/provider-aws-fis
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-fis
+- image: xpkg.upbound.io/upbound/provider-aws-osis
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-osis
+- image: xpkg.upbound.io/upbound/provider-aws-servicequotas
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-servicequotas
+- image: xpkg.upbound.io/upbound/provider-aws-iot
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-iot
+- image: xpkg.upbound.io/upbound/provider-aws-wafv2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-wafv2
+- image: xpkg.upbound.io/upbound/provider-aws-organizations
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-organizations
+- image: xpkg.upbound.io/upbound/provider-aws-directconnect
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-directconnect
+- image: xpkg.upbound.io/upbound/provider-aws-accessanalyzer
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-accessanalyzer
+- image: xpkg.upbound.io/upbound/provider-aws-serverlessrepo
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-serverlessrepo
+- image: xpkg.upbound.io/upbound/provider-aws-imagebuilder
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-imagebuilder
+- image: xpkg.upbound.io/upbound/provider-aws-inspector
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-inspector
+- image: xpkg.upbound.io/upbound/provider-aws-autoscalingplans
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-autoscalingplans
+- image: xpkg.upbound.io/upbound/provider-aws-glacier
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-glacier
+- image: xpkg.upbound.io/upbound/provider-aws-codestarnotifications
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-codestarnotifications
+- image: xpkg.upbound.io/upbound/provider-aws-cloudwatchevents
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudwatchevents
+- image: xpkg.upbound.io/upbound/provider-aws-ram
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ram
+- image: xpkg.upbound.io/upbound/provider-aws-codepipeline
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-codepipeline
+- image: xpkg.upbound.io/upbound/provider-aws-keyspaces
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-keyspaces
+- image: xpkg.upbound.io/upbound/provider-aws-apigatewayv2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-apigatewayv2
+- image: xpkg.upbound.io/upbound/provider-aws-dms
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-dms
+- image: xpkg.upbound.io/upbound/provider-aws-kms
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kms
+- image: xpkg.upbound.io/upbound/provider-aws-mwaa
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-mwaa
+- image: xpkg.upbound.io/upbound/provider-aws-redshiftserverless
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-redshiftserverless
+- image: xpkg.upbound.io/upbound/provider-aws-elasticbeanstalk
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-elasticbeanstalk
+- image: xpkg.upbound.io/upbound/provider-aws-appmesh
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appmesh
+- image: xpkg.upbound.io/upbound/provider-aws-pipes
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-pipes
+- image: xpkg.upbound.io/upbound/provider-aws-ec2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ec2
+- image: xpkg.upbound.io/upbound/provider-aws-gamelift
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-gamelift
+- image: xpkg.upbound.io/upbound/provider-aws-sfn
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-sfn
+- image: xpkg.upbound.io/upbound/provider-aws-timestreamwrite
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-timestreamwrite
+- image: xpkg.upbound.io/upbound/provider-aws-mediaconvert
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-mediaconvert
+- image: xpkg.upbound.io/upbound/provider-aws-lambda
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-lambda
+- image: xpkg.upbound.io/upbound/provider-aws-scheduler
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-scheduler
+- image: xpkg.upbound.io/upbound/provider-aws-vpc
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-vpc
+- image: xpkg.upbound.io/upbound/provider-aws-cloudwatchlogs
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudwatchlogs
+- image: xpkg.upbound.io/upbound/provider-aws-transfer
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-transfer
+- image: xpkg.upbound.io/upbound/provider-aws-inspector2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-inspector2
+- image: xpkg.upbound.io/upbound/provider-aws-route53
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-route53
+- image: xpkg.upbound.io/upbound/provider-aws-codeartifact
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-codeartifact
+- image: xpkg.upbound.io/upbound/provider-aws-medialive
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-medialive
+- image: xpkg.upbound.io/upbound/provider-aws-lexmodels
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-lexmodels
+- image: xpkg.upbound.io/upbound/provider-aws-appflow
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appflow
+- image: xpkg.upbound.io/upbound/provider-aws-chime
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-chime
+- image: xpkg.upbound.io/upbound/provider-aws-batch
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-batch
+- image: xpkg.upbound.io/upbound/provider-aws-transcribe
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-transcribe
+- image: xpkg.upbound.io/upbound/provider-aws-route53recoveryreadiness
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-route53recoveryreadiness
+- image: xpkg.upbound.io/upbound/provider-aws-apprunner
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-apprunner
+- image: xpkg.upbound.io/upbound/provider-aws-lightsail
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-lightsail
+- image: xpkg.upbound.io/upbound/provider-aws-emrserverless
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-emrserverless
+- image: xpkg.upbound.io/upbound/provider-aws-elb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-elb
+- image: xpkg.upbound.io/upbound/provider-aws-datapipeline
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-datapipeline
+- image: xpkg.upbound.io/upbound/provider-aws-dataexchange
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-dataexchange
+- image: xpkg.upbound.io/upbound/provider-aws-s3control
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-s3control
+- image: xpkg.upbound.io/upbound/provider-aws-macie2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-macie2
+- image: xpkg.upbound.io/upbound/provider-aws-securityhub
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-securityhub
+- image: xpkg.upbound.io/upbound/provider-aws-backup
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-backup
+- image: xpkg.upbound.io/upbound/provider-aws-rds
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-rds
+- image: xpkg.upbound.io/upbound/provider-aws-glue
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-glue
+- image: xpkg.upbound.io/upbound/provider-aws-s3
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-s3
+- image: xpkg.upbound.io/upbound/provider-aws-kinesisvideo
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kinesisvideo
+- image: xpkg.upbound.io/upbound/provider-aws-globalaccelerator
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-globalaccelerator
+- image: xpkg.upbound.io/upbound/provider-aws-sqs
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-sqs
+- image: xpkg.upbound.io/upbound/provider-aws-appstream
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appstream
+- image: xpkg.upbound.io/upbound/provider-aws-firehose
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-firehose
+- image: xpkg.upbound.io/upbound/provider-aws-networkmanager
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-networkmanager
+- image: xpkg.upbound.io/upbound/provider-aws-cloudcontrol
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudcontrol
+- image: xpkg.upbound.io/upbound/provider-aws-secretsmanager
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-secretsmanager
+- image: xpkg.upbound.io/upbound/provider-aws-kinesis
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kinesis
+- image: xpkg.upbound.io/upbound/provider-aws-mediastore
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-mediastore
+- image: xpkg.upbound.io/upbound/provider-aws-detective
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-detective
+- image: xpkg.upbound.io/upbound/provider-aws-memorydb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-memorydb
+- image: xpkg.upbound.io/upbound/provider-aws-bedrockagent
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-bedrockagent
+- image: xpkg.upbound.io/upbound/provider-aws-acm
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-acm
+- image: xpkg.upbound.io/upbound/provider-aws-mq
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-mq
+- image: xpkg.upbound.io/upbound/provider-aws-ecrpublic
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ecrpublic
+- image: xpkg.upbound.io/upbound/provider-aws-appintegrations
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appintegrations
+- image: xpkg.upbound.io/upbound/provider-aws-waf
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-waf
+- image: xpkg.upbound.io/upbound/provider-aws-amplify
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-amplify
+- image: xpkg.upbound.io/upbound/provider-aws-dynamodb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-dynamodb
+- image: xpkg.upbound.io/upbound/provider-aws-apigateway
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-apigateway
+- image: xpkg.upbound.io/upbound/provider-aws-cognitoidentity
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cognitoidentity
+- image: xpkg.upbound.io/upbound/provider-aws-kinesisanalyticsv2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kinesisanalyticsv2
+- image: xpkg.upbound.io/upbound/provider-aws-simpledb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-simpledb
+- image: xpkg.upbound.io/upbound/provider-aws-servicecatalog
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-servicecatalog
+- image: xpkg.upbound.io/upbound/provider-aws-guardduty
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-guardduty
+- image: xpkg.upbound.io/upbound/provider-aws-kafkaconnect
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kafkaconnect
+- image: xpkg.upbound.io/upbound/provider-aws-lakeformation
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-lakeformation
+- image: xpkg.upbound.io/upbound/provider-aws-cloudfront
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudfront
+- image: xpkg.upbound.io/upbound/provider-aws-emr
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-emr
+- image: xpkg.upbound.io/upbound/provider-aws-location
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-location
+- image: xpkg.upbound.io/upbound/provider-aws-account
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-account
+- image: xpkg.upbound.io/upbound/provider-aws-ssm
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ssm
+- image: xpkg.upbound.io/upbound/provider-aws-grafana
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-grafana
+- image: xpkg.upbound.io/upbound/provider-aws-ecr
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ecr
+- image: xpkg.upbound.io/upbound/provider-aws-wafregional
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-wafregional
+- image: xpkg.upbound.io/upbound/provider-aws-autoscaling
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-autoscaling
+- image: xpkg.upbound.io/upbound/provider-aws-cloud9
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloud9
+- image: xpkg.upbound.io/upbound/provider-aws-evidently
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-evidently
+- image: xpkg.upbound.io/upbound/provider-aws-ds
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ds
+- image: xpkg.upbound.io/upbound/provider-aws-resourcegroups
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-resourcegroups
+- image: xpkg.upbound.io/upbound/provider-aws-qldb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-qldb
+- image: xpkg.upbound.io/upbound/provider-aws-opensearch
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-opensearch
+- image: xpkg.upbound.io/upbound/provider-aws-codestarconnections
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-codestarconnections
+- image: xpkg.upbound.io/upbound/provider-aws-cloudsearch
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudsearch
+- image: xpkg.upbound.io/upbound/provider-aws-fsx
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-fsx
+- image: xpkg.upbound.io/upbound/provider-aws-elasticsearch
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-elasticsearch
+- image: xpkg.upbound.io/upbound/provider-aws-pinpoint
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-pinpoint
+- image: xpkg.upbound.io/upbound/provider-aws-ecs
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ecs
+- image: xpkg.upbound.io/upbound/provider-aws-codeguruprofiler
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-codeguruprofiler
+- image: xpkg.upbound.io/upbound/provider-aws-ssoadmin
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ssoadmin
+- image: xpkg.upbound.io/upbound/provider-aws-kafka
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kafka
+- image: xpkg.upbound.io/upbound/provider-aws-datasync
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-datasync
+- image: xpkg.upbound.io/upbound/provider-aws-appconfig
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appconfig
+- image: xpkg.upbound.io/upbound/provider-aws-iam
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-iam
+- image: xpkg.upbound.io/upbound/provider-aws-dax
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-dax
+- image: xpkg.upbound.io/upbound/provider-aws-elastictranscoder
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-elastictranscoder
+- image: xpkg.upbound.io/upbound/provider-aws-deploy
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-deploy
+- image: xpkg.upbound.io/upbound/provider-aws-connect
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-connect
+- image: xpkg.upbound.io/upbound/provider-aws-opensearchserverless
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-opensearchserverless
+- image: xpkg.upbound.io/upbound/provider-aws-licensemanager
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-licensemanager
+- image: xpkg.upbound.io/upbound/provider-aws-athena
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-athena
+- image: xpkg.upbound.io/upbound/provider-aws-signer
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-signer
+- image: xpkg.upbound.io/upbound/provider-aws-kinesisanalytics
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-kinesisanalytics
+- image: xpkg.upbound.io/upbound/provider-aws-route53recoverycontrolconfig
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-route53recoverycontrolconfig
+- image: xpkg.upbound.io/upbound/provider-aws-networkfirewall
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-networkfirewall
+- image: xpkg.upbound.io/upbound/provider-aws-identitystore
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-identitystore
+- image: xpkg.upbound.io/upbound/provider-aws-sesv2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-sesv2
+- image: xpkg.upbound.io/upbound/provider-aws-elasticache
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-elasticache
+- image: xpkg.upbound.io/upbound/provider-aws-amp
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-amp
+- image: xpkg.upbound.io/upbound/provider-aws-redshift
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-redshift
+- image: xpkg.upbound.io/upbound/provider-aws-cloudtrail
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-cloudtrail
+- image: xpkg.upbound.io/upbound/provider-aws-eks
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-eks
+- image: xpkg.upbound.io/upbound/provider-aws-appsync
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-appsync
+- image: xpkg.upbound.io/upbound/provider-aws-xray
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-xray
+- image: xpkg.upbound.io/upbound/provider-aws-sagemaker
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-sagemaker
+- image: xpkg.upbound.io/upbound/provider-aws-efs
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-efs
+- image: xpkg.upbound.io/upbound/provider-aws-ivs
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-aws-ivs

--- a/images/renamed-upbound-azure.yaml
+++ b/images/renamed-upbound-azure.yaml
@@ -1,0 +1,279 @@
+- image: xpkg.upbound.io/upbound/provider-family-azure
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-family-azure
+- image: xpkg.upbound.io/upbound/provider-azure-storagesync
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-storagesync
+- image: xpkg.upbound.io/upbound/provider-azure-purview
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-purview
+- image: xpkg.upbound.io/upbound/provider-azure-servicefabric
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-servicefabric
+- image: xpkg.upbound.io/upbound/provider-azure-keyvault
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-keyvault
+- image: xpkg.upbound.io/upbound/provider-azure-databoxedge
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-databoxedge
+- image: xpkg.upbound.io/upbound/provider-azure-logic
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-logic
+- image: xpkg.upbound.io/upbound/provider-azure-cdn
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-cdn
+- image: xpkg.upbound.io/upbound/provider-azure-sql
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-sql
+- image: xpkg.upbound.io/upbound/provider-azure-maps
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-maps
+- image: xpkg.upbound.io/upbound/provider-azure-consumption
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-consumption
+- image: xpkg.upbound.io/upbound/provider-azure-spring
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-spring
+- image: xpkg.upbound.io/upbound/provider-azure-hdinsight
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-hdinsight
+- image: xpkg.upbound.io/upbound/provider-azure-authorization
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-authorization
+- image: xpkg.upbound.io/upbound/provider-azure-powerbidedicated
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-powerbidedicated
+- image: xpkg.upbound.io/upbound/provider-azure-loadtestservice
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-loadtestservice
+- image: xpkg.upbound.io/upbound/provider-azure-confidentialledger
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-confidentialledger
+- image: xpkg.upbound.io/upbound/provider-azure-storage
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-storage
+- image: xpkg.upbound.io/upbound/provider-azure-timeseriesinsights
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-timeseriesinsights
+- image: xpkg.upbound.io/upbound/provider-azure-policyinsights
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-policyinsights
+- image: xpkg.upbound.io/upbound/provider-azure-recoveryservices
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-recoveryservices
+- image: xpkg.upbound.io/upbound/provider-azure-devices
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-devices
+- image: xpkg.upbound.io/upbound/provider-azure-media
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-media
+- image: xpkg.upbound.io/upbound/provider-azure-cosmosdb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-cosmosdb
+- image: xpkg.upbound.io/upbound/provider-azure-certificateregistration
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-certificateregistration
+- image: xpkg.upbound.io/upbound/provider-azure-solutions
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-solutions
+- image: xpkg.upbound.io/upbound/provider-azure-healthcareapis
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-healthcareapis
+- image: xpkg.upbound.io/upbound/provider-azure-attestation
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-attestation
+- image: xpkg.upbound.io/upbound/provider-azure-datamigration
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-datamigration
+- image: xpkg.upbound.io/upbound/provider-azure-analysisservices
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-analysisservices
+- image: xpkg.upbound.io/upbound/provider-azure-kusto
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-kusto
+- image: xpkg.upbound.io/upbound/provider-azure-mixedreality
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-mixedreality
+- image: xpkg.upbound.io/upbound/provider-azure-iotcentral
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-iotcentral
+- image: xpkg.upbound.io/upbound/provider-azure-security
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-security
+- image: xpkg.upbound.io/upbound/provider-azure-automation
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-automation
+- image: xpkg.upbound.io/upbound/provider-azure-databricks
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-databricks
+- image: xpkg.upbound.io/upbound/provider-azure-notificationhubs
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-notificationhubs
+- image: xpkg.upbound.io/upbound/provider-azure-orbital
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-orbital
+- image: xpkg.upbound.io/upbound/provider-azure-customproviders
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-customproviders
+- image: xpkg.upbound.io/upbound/provider-azure-labservices
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-labservices
+- image: xpkg.upbound.io/upbound/provider-azure-cache
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-cache
+- image: xpkg.upbound.io/upbound/provider-azure-deviceupdate
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-deviceupdate
+- image: xpkg.upbound.io/upbound/provider-azure-fluidrelay
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-fluidrelay
+- image: xpkg.upbound.io/upbound/provider-azure-network
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-network
+- image: xpkg.upbound.io/upbound/provider-azure-botservice
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-botservice
+- image: xpkg.upbound.io/upbound/provider-azure-resources
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-resources
+- image: xpkg.upbound.io/upbound/provider-azure-dbformariadb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-dbformariadb
+- image: xpkg.upbound.io/upbound/provider-azure-signalrservice
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-signalrservice
+- image: xpkg.upbound.io/upbound/provider-azure-healthbot
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-healthbot
+- image: xpkg.upbound.io/upbound/provider-azure-dataprotection
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-dataprotection
+- image: xpkg.upbound.io/upbound/provider-azure-containerapp
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-containerapp
+- image: xpkg.upbound.io/upbound/provider-azure-servicelinker
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-servicelinker
+- image: xpkg.upbound.io/upbound/provider-azure-maintenance
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-maintenance
+- image: xpkg.upbound.io/upbound/provider-azure-streamanalytics
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-streamanalytics
+- image: xpkg.upbound.io/upbound/provider-azure-search
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-search
+- image: xpkg.upbound.io/upbound/provider-azure-storagecache
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-storagecache
+- image: xpkg.upbound.io/upbound/provider-azure-appconfiguration
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-appconfiguration
+- image: xpkg.upbound.io/upbound/provider-azure-servicebus
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-servicebus
+- image: xpkg.upbound.io/upbound/provider-azure-azurestackhci
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-azurestackhci
+- image: xpkg.upbound.io/upbound/provider-azure-managedidentity
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-managedidentity
+- image: xpkg.upbound.io/upbound/provider-azure-storagepool
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-storagepool
+- image: xpkg.upbound.io/upbound/provider-azure-digitaltwins
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-digitaltwins
+- image: xpkg.upbound.io/upbound/provider-azure-logz
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-logz
+- image: xpkg.upbound.io/upbound/provider-azure-communication
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-communication
+- image: xpkg.upbound.io/upbound/provider-azure-securityinsights
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-securityinsights
+- image: xpkg.upbound.io/upbound/provider-azure-eventhub
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-eventhub
+- image: xpkg.upbound.io/upbound/provider-azure-management
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-management
+- image: xpkg.upbound.io/upbound/provider-azure-relay
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-relay
+- image: xpkg.upbound.io/upbound/provider-azure-dbformysql
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-dbformysql
+- image: xpkg.upbound.io/upbound/provider-azure-machinelearningservices
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-machinelearningservices
+- image: xpkg.upbound.io/upbound/provider-azure-cognitiveservices
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-cognitiveservices
+- image: xpkg.upbound.io/upbound/provider-azure-dbforpostgresql
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-dbforpostgresql
+- image: xpkg.upbound.io/upbound/provider-azure-datafactory
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-datafactory
+- image: xpkg.upbound.io/upbound/provider-azure-appplatform
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-appplatform
+- image: xpkg.upbound.io/upbound/provider-azure-guestconfiguration
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-guestconfiguration
+- image: xpkg.upbound.io/upbound/provider-azure-containerregistry
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-containerregistry
+- image: xpkg.upbound.io/upbound/provider-azure-containerservice
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-containerservice
+- image: xpkg.upbound.io/upbound/provider-azure-operationalinsights
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-operationalinsights
+- image: xpkg.upbound.io/upbound/provider-azure-operationsmanagement
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-operationsmanagement
+- image: xpkg.upbound.io/upbound/provider-azure-alertsmanagement
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-alertsmanagement
+- image: xpkg.upbound.io/upbound/provider-azure-web
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-web
+- image: xpkg.upbound.io/upbound/provider-azure-elastic
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-elastic
+- image: xpkg.upbound.io/upbound/provider-azure-apimanagement
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-apimanagement
+- image: xpkg.upbound.io/upbound/provider-azure-devtestlab
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-devtestlab
+- image: xpkg.upbound.io/upbound/provider-azure-eventgrid
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-eventgrid
+- image: xpkg.upbound.io/upbound/provider-azure-compute
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-compute
+- image: xpkg.upbound.io/upbound/provider-azure-datashare
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-datashare
+- image: xpkg.upbound.io/upbound/provider-azure-marketplaceordering
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-marketplaceordering
+- image: xpkg.upbound.io/upbound/provider-azure-costmanagement
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-costmanagement
+- image: xpkg.upbound.io/upbound/provider-azure-netapp
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-netapp
+- image: xpkg.upbound.io/upbound/provider-azure-portal
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-portal
+- image: xpkg.upbound.io/upbound/provider-azure-insights
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-insights
+- image: xpkg.upbound.io/upbound/provider-azure-synapse
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-azure-synapse

--- a/images/renamed-upbound-gcp.yaml
+++ b/images/renamed-upbound-gcp.yaml
@@ -1,0 +1,222 @@
+- image: xpkg.upbound.io/upbound/provider-family-gcp
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-family-gcp
+- image: xpkg.upbound.io/upbound/provider-gcp-binaryauthorization
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-binaryauthorization
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudfunctions
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudfunctions
+- image: xpkg.upbound.io/upbound/provider-gcp-sql
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-sql
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudtasks
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudtasks
+- image: xpkg.upbound.io/upbound/provider-gcp-appengine
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-appengine
+- image: xpkg.upbound.io/upbound/provider-gcp-apigee
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-apigee
+- image: xpkg.upbound.io/upbound/provider-gcp-datastore
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-datastore
+- image: xpkg.upbound.io/upbound/provider-gcp-certificatemanager
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-certificatemanager
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudrun
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudrun
+- image: xpkg.upbound.io/upbound/provider-gcp-mlengine
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-mlengine
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudscheduler
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudscheduler
+- image: xpkg.upbound.io/upbound/provider-gcp-storage
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-storage
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudfunctions2
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudfunctions2
+- image: xpkg.upbound.io/upbound/provider-gcp-artifact
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-artifact
+- image: xpkg.upbound.io/upbound/provider-gcp-cloud
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloud
+- image: xpkg.upbound.io/upbound/provider-gcp-healthcare
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-healthcare
+- image: xpkg.upbound.io/upbound/provider-gcp-pubsub
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-pubsub
+- image: xpkg.upbound.io/upbound/provider-gcp-beyondcorp
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-beyondcorp
+- image: xpkg.upbound.io/upbound/provider-gcp-filestore
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-filestore
+- image: xpkg.upbound.io/upbound/provider-gcp-documentai
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-documentai
+- image: xpkg.upbound.io/upbound/provider-gcp-kms
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-kms
+- image: xpkg.upbound.io/upbound/provider-gcp-memcache
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-memcache
+- image: xpkg.upbound.io/upbound/provider-gcp-vertexai
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-vertexai
+- image: xpkg.upbound.io/upbound/provider-gcp-alloydb
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-alloydb
+- image: xpkg.upbound.io/upbound/provider-gcp-dataflow
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-dataflow
+- image: xpkg.upbound.io/upbound/provider-gcp-datacatalog
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-datacatalog
+- image: xpkg.upbound.io/upbound/provider-gcp-essentialcontacts
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-essentialcontacts
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudbuild
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudbuild
+- image: xpkg.upbound.io/upbound/provider-gcp-secretmanager
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-secretmanager
+- image: xpkg.upbound.io/upbound/provider-gcp-containerazure
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-containerazure
+- image: xpkg.upbound.io/upbound/provider-gcp-datafusion
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-datafusion
+- image: xpkg.upbound.io/upbound/provider-gcp-redis
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-redis
+- image: xpkg.upbound.io/upbound/provider-gcp-cloudplatform
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-cloudplatform
+- image: xpkg.upbound.io/upbound/provider-gcp-sourcerepo
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-sourcerepo
+- image: xpkg.upbound.io/upbound/provider-gcp-container
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-container
+- image: xpkg.upbound.io/upbound/provider-gcp-composer
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-composer
+- image: xpkg.upbound.io/upbound/provider-gcp-monitoring
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-monitoring
+- image: xpkg.upbound.io/upbound/provider-gcp-activedirectory
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-activedirectory
+- image: xpkg.upbound.io/upbound/provider-gcp-logging
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-logging
+- image: xpkg.upbound.io/upbound/provider-gcp-identityplatform
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-identityplatform
+- image: xpkg.upbound.io/upbound/provider-gcp-iap
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-iap
+- image: xpkg.upbound.io/upbound/provider-gcp-oslogin
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-oslogin
+- image: xpkg.upbound.io/upbound/provider-gcp-firebaserules
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-firebaserules
+- image: xpkg.upbound.io/upbound/provider-gcp-vpcaccess
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-vpcaccess
+- image: xpkg.upbound.io/upbound/provider-gcp-networkmanagement
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-networkmanagement
+- image: xpkg.upbound.io/upbound/provider-gcp-bigtable
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-bigtable
+- image: xpkg.upbound.io/upbound/provider-gcp-osconfig
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-osconfig
+- image: xpkg.upbound.io/upbound/provider-gcp-dns
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-dns
+- image: xpkg.upbound.io/upbound/provider-gcp-containeraws
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-containeraws
+- image: xpkg.upbound.io/upbound/provider-gcp-dialogflowcx
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-dialogflowcx
+- image: xpkg.upbound.io/upbound/provider-gcp-containeranalysis
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-containeranalysis
+- image: xpkg.upbound.io/upbound/provider-gcp-dataproc
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-dataproc
+- image: xpkg.upbound.io/upbound/provider-gcp-privateca
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-privateca
+- image: xpkg.upbound.io/upbound/provider-gcp-tags
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-tags
+- image: xpkg.upbound.io/upbound/provider-gcp-workflows
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-workflows
+- image: xpkg.upbound.io/upbound/provider-gcp-datalossprevention
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-datalossprevention
+- image: xpkg.upbound.io/upbound/provider-gcp-bigquery
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-bigquery
+- image: xpkg.upbound.io/upbound/provider-gcp-servicenetworking
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-servicenetworking
+- image: xpkg.upbound.io/upbound/provider-gcp-gkehub
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-gkehub
+- image: xpkg.upbound.io/upbound/provider-gcp-datastream
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-datastream
+- image: xpkg.upbound.io/upbound/provider-gcp-spanner
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-spanner
+- image: xpkg.upbound.io/upbound/provider-gcp-orgpolicy
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-orgpolicy
+- image: xpkg.upbound.io/upbound/provider-gcp-dataplex
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-dataplex
+- image: xpkg.upbound.io/upbound/provider-gcp-iam
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-iam
+- image: xpkg.upbound.io/upbound/provider-gcp-eventarc
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-eventarc
+- image: xpkg.upbound.io/upbound/provider-gcp-gke
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-gke
+- image: xpkg.upbound.io/upbound/provider-gcp-containerattached
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-containerattached
+- image: xpkg.upbound.io/upbound/provider-gcp-tpu
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-tpu
+- image: xpkg.upbound.io/upbound/provider-gcp-networkconnectivity
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-networkconnectivity
+- image: xpkg.upbound.io/upbound/provider-gcp-accesscontextmanager
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-accesscontextmanager
+- image: xpkg.upbound.io/upbound/provider-gcp-compute
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-compute
+- image: xpkg.upbound.io/upbound/provider-gcp-notebooks
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-notebooks
+- image: xpkg.upbound.io/upbound/provider-gcp-storagetransfer
+  semver: ">= 1.0.0"
+  override_repo_name: upbound-provider-gcp-storagetransfer

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	skopeoSyncOutputPattern = regexp.MustCompile(`Would have copied image.*?from="docker://(.*?)[@:](.*?)".*`)
 	temporaryWorkingDir     = path.Join(os.TempDir(), "retagger")
 
+	flagFile             string
 	flagLogLevel         string
 	flagExecutorCount    int
 	flagExecutorID       int
@@ -421,6 +422,7 @@ func command(name string, args ...string) (*exec.Cmd, *bytes.Buffer, *bytes.Buff
 }
 
 func init() {
+	flag.StringVar(&flagFile, "filename", renamedImagesFile, "Sets the file to use for renaming")
 	flag.StringVar(&flagLogLevel, "log-level", "debug", "Sets log level")
 	// `retagger run` flags
 	flag.IntVar(&flagExecutorCount, "executor-count", 1, "Number of executors in a parallelized run. Used with 'retagger run'.")
@@ -465,15 +467,17 @@ func commandRun() {
 
 	logger := logrus.WithField("executor", flagExecutorID)
 
+	logger.Infof("Using file %q", flagFile)
+
 	// Load renamed image definitions from a file
 	var renamedImages []RenamedImage
 	{
-		b, err := os.ReadFile(renamedImagesFile)
+		b, err := os.ReadFile(flagFile)
 		if err != nil {
-			logger.Fatalf("error reading %q: %s", renamedImagesFile, err)
+			logger.Fatalf("error reading %q: %s", flagFile, err)
 		}
 		if err := yaml.Unmarshal(b, &renamedImages); err != nil {
-			logger.Fatalf("error unmarshaling %q: %s", renamedImagesFile, err)
+			logger.Fatalf("error unmarshaling %q: %s", flagFile, err)
 		}
 	}
 


### PR DESCRIPTION
Upbound is hiding older tags of their official images behind an enterprise subscription from the 31st January. This puts us in the position of requiring their providers to be copied to our registries in order for us to maintain our current state and be able to support into the future.

In order to ensure that we retag all official providers, this change introduces a new flag to retagger code to accept a filename for retagging and renaming images. This is then passed to retagger via the matrix job so each file is executed concurrently across the available executors.

Additional rename files were introduced, one for each provider family containing all known APIs for that provider family. This split was undertaken to prevent one single file from containing thousands of images to retag, better enabling concurrent executions.