### PR TITLE
Update patterns for golang

### DIFF
--- a/images/renamed-images.yaml
+++ b/images/renamed-images.yaml
@@ -48,8 +48,8 @@
   semver: ">= v2.7.1"
   override_repo_name: csi-vsphere-syncer
 - image: golang
-  semver: ">= 1.21.6"
-  filter: "(.+)-alpine3.19"
+  semver: ">= 1.23.0"
+  filter: "(.+)-alpine3.2[0-9]"
 - image: ghcr.io/cloudnative-pg/postgresql
   override_repo_name: postgresql-cnpg
   semver: ">= 15.6"

--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -29,18 +29,6 @@ docker.io:
       - "6.8.13"
     fluxcd/flux-cli:
       - "v0.27.0"
-    golang:
-      - "1.14.1-alpine3.11"
-      - "1.15.2-alpine3.12"
-      - "1.16-alpine3.12"
-      - "1.16.7-alpine3.14"
-      - "1.17.1-alpine3.14"
-      - "1.17.7-alpine3.14"
-      - "1.17.8-alpine3.14"
-      - "1.18.1-alpine3.15"
-      - "1.19.1-alpine3.16"
-      - "1.20.6-alpine3.17"
-      # Future `golang` versions are now handled in `renamed-images.yaml` to automatically match alpine tags via semver
     golangci/golangci-lint:
       - "v1.23.8"
     instrumenta/conftest:


### PR DESCRIPTION
Purpose:

- Catch more recent Alpine versions (latest is 3.21)
- Skip 1.21.* and 1.22.* Go versions when syncing (current is 1.23.6)
- Also remove config for old tags that have long been pulled and are no longer relevant