### PR TITLE
update kube-downscaler image

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -151,7 +151,6 @@ docker.io:
     k8scloudprovider/openstack-cloud-controller-manager: ">= 1.20.0"
     kiwigrid/k8s-sidecar: ">= 1.24.3"
     kong: ">= 2.8.1"
-    hjacobs/kube-downscaler: ">= 23.2.0"
     mikefarah/yq: ">= 4.31.2"
     mintel/dex-k8s-authenticator: ">= 1.4.0"
     openpolicyagent/conftest: ">= v0.25.0"

--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -23,6 +23,7 @@ ghcr.io:
     kedacore/keda-admission-webhooks: ">= 2.10.1"
     kedacore/keda: ">= 2.10.1"
     kedacore/keda-metrics-apiserver: ">= 2.10.1"
+    caas-team/kube-downscaler: ">= 25.2.0"
     kube-vip/kube-vip: ">= v0.6.3"
     kube-vip/kube-vip-cloud-provider: ">= v0.0.4"
     kyverno/background-controller: ">= v1.10.1"


### PR DESCRIPTION
With the migration of kube-downscaler to the new upstream project, we should as well use their image.