### PR TITLE
Add regex for grafana security images

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -169,3 +169,5 @@ docker.io:
     alpine: ^3\.[123][0-9]\.[0-9]+$
     memcached: ^1\.[6-9]\.[0-9]+-alpine$
     nginx: ^1\.2[3-9]-alpine$
+    # grafana security images for grafana 10+ - tag looks like `12.0.0-security-01`
+    grafana/grafana: ^[1-9][0-9]\.[0-9]+\.[0-9]+-security-[0-9]+$


### PR DESCRIPTION
I discovered in a grafana upgrade PR (here: https://github.com/giantswarm/grafana-app/pull/315) that grafana started generating `security` images.
This change ensures we can deploy them.