### PR TITLE
Stop retagging yamllint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             docker run --rm -it \
              -v $PWD:/workdir \
              -w /workdir \
-             gsoci.azurecr.io/giantswarm/yamllint:1.26@sha256:1bf8270a671a2e5f2fea8ac2e80164d627e0c5fa083759862bbde80628f942b2 \
+             gsoci.azurecr.io/giantswarm/yamllint:1.0.0 \
              --config-file /workdir/.yamllint \
              images/*.yaml
       - persist_to_workspace:

--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -121,7 +121,6 @@ docker.io:
     busybox: ">= 1.31.0"
     crossplane/crossplane: ">= v1.9.1"
     curlimages/curl: ">= 7.67.0"
-    cytopia/yamllint: ">= 1.9"
     ealen/echo-server: ">=0.5.0"
     envoyproxy/envoy: ">= 1.18.4"
     falcosecurity/falco: ">= 0.36.1"


### PR DESCRIPTION
This PR ends the retagging of `cytopia/yamllint`.

In addition, it replaces the image used in CI with our own created from https://github.com/giantswarm/yamllint