### PR TITLE
Remove memcached and memcached-exporter image config

### DIFF
--- a/images/renamed-images.yaml
+++ b/images/renamed-images.yaml
@@ -6,14 +6,6 @@
   override_repo_name: awscli
   tag_or_pattern: "2.7.35"
   sha: e5988c45f13ec9c9500e9fb6742e19de642a5bdc2750f2cc0482a857f13c30ea
-- image: bitnami/memcached
-  override_repo_name: bitnami-memcached
-  tag_or_pattern: "1.6.21"
-  sha: 247ec29efd6030960047a623aef025021154662edf6b6d6e88c97936f164d99d
-- image: bitnami/memcached-exporter
-  override_repo_name: bitnami-memcached-exporter
-  tag_or_pattern: "0.13.0"
-  sha: ed4cb413c2074a2ac62005d0da61d5a6872382f318c206506b3f200fa8900442
 - image: bitnami/redis
   override_repo_name: bitnami-redis
   tag_or_pattern: "4.0.9"


### PR DESCRIPTION
Apparently they were only used in https://github.com/giantswarm/memcached-app which is archived.

Towards https://github.com/giantswarm/giantswarm/issues/34051