### PR TITLE
retag nginx v1.30+

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -173,8 +173,8 @@ docker.io:
     # this will fail with release of go 1.100. Hopefully not soon.
     golang: "^1.[2-9][0-9].[0-9]+(-alpine.+)?$"
     memcached: ^1\.[6-9]\.[0-9]+-alpine$
-    nginx: ^1\.2[3-9]-alpine$
-    nginxinc/nginx-unprivileged: ^1\.2[3-9]-alpine$
+    nginx: ^1\.(2[3-9]|[3-9][0-9])-alpine$
+    nginxinc/nginx-unprivileged: ^1\.(2[3-9]|[3-9][0-9])-alpine$
     # grafana security images for grafana 10+ - tag looks like `12.0.0-security-01`
     grafana/grafana: ^[1-9][0-9]\.[0-9]+\.[0-9]+-security-[0-9]+$
     envoyproxy/envoy: ^distroless-v1\.[0-9]+\.[0-9]+$

--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -51,5 +51,5 @@ ghcr.io:
     slok/sloth: ">= v0.11.0"
     vmware/pinniped/pinniped-server: ">= v0.40.0"
   images-by-tag-regex:
-    nginxinc/nginx-unprivileged: ^1\.2[3-9]-alpine$
+    nginxinc/nginx-unprivileged: ^1\.(2[3-9]|[3-9][0-9])-alpine$
     k8snetworkplumbingwg/multus-cni: v([0-9].){2}[0-9]-thick$


### PR DESCRIPTION
Latest nginx images are 1.30.
Current retagging was stopping at 1.29.
This PR allows retagging of images 1.30+.

Needed for https://github.com/giantswarm/loki-app/pull/507