### PR TITLE
Add agentgateway controller + data-plane images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,6 +557,7 @@ build_and_retag: &build_and_retag
           parameters:
             filename:
               - images/renamed-images.yaml
+              - images/renamed-agentgateway.yaml
               - images/renamed-cilium-prereleases.yaml
               - images/renamed-upbound-aws.yaml
               - images/renamed-upbound-azure.yaml

--- a/images/renamed-agentgateway.yaml
+++ b/images/renamed-agentgateway.yaml
@@ -1,0 +1,6 @@
+- image: cr.agentgateway.dev/controller
+  override_repo_name: agentgateway-controller
+  semver: ">= v1.2.0"
+- image: cr.agentgateway.dev/agentgateway
+  override_repo_name: agentgateway
+  semver: ">= v1.2.0"


### PR DESCRIPTION
## Summary

Mirror the two upstream agentgateway images into `gsoci.azurecr.io/giantswarm/` so the team-bumblebee `agentic-platform` umbrella chart (https://github.com/giantswarm/agentic-platform) can default to GS-retagged image refs instead of pulling directly from `cr.agentgateway.dev`.

| Source | Target | Tag filter |
|---|---|---|
| `cr.agentgateway.dev/controller` | `gsoci.azurecr.io/giantswarm/agentgateway-controller` | `semver: ">= v1.2.0"` |
| `cr.agentgateway.dev/agentgateway` | `gsoci.azurecr.io/giantswarm/agentgateway` | `semver: ">= v1.2.0"` |

`controller` gets `override_repo_name: agentgateway-controller` because the bare name is too generic for `gsoci.azurecr.io/giantswarm/`. `agentgateway` keeps its name.

## Prerequisite for merge

Per the retagger README: the target repositories must exist in `gsoci.azurecr.io/giantswarm/` (and the Aliyun mirror) before the retag job runs successfully. Please confirm `agentgateway-controller` and `agentgateway` repos are pre-created.

## Downstream

The agentic-platform umbrella PR (https://github.com/giantswarm/agentic-platform/pull/1) is blocked on this — once the retag pipeline runs and the images are available, the umbrella's `agentgateway.image.registry` and `agentgateway.proxy.image.registry` defaults can move from `cr.agentgateway.dev` to `gsoci.azurecr.io`.