### PR TITLE
add prometheus distroless images

### DIFF
--- a/images/skopeo-quay-io.yaml
+++ b/images/skopeo-quay-io.yaml
@@ -41,3 +41,8 @@ quay.io:
     prometheus/alertmanager: ">= v0.25.0"
     prometheus/node-exporter: ">= v1.8.2"
     uswitch/kiam: ">= v4.2.0"
+  images-by-tag-regex:
+    # Tags look like `v3.11.3-distroless`, we match v3.11 and above
+    prometheus/prometheus: ^v(3\.(1[1-9]|[2-9][0-9])|[4-9]\.[0-9]+)\.[0-9]+-distroless$
+    # Tags look like `v1.11.1-distroless`, we match v1.11 and above
+    prometheus/node-exporter: ^v(1\.(1[1-9]|[2-9][0-9])|[2-9]\.[0-9]+)\.[0-9]+-distroless$


### PR DESCRIPTION
Towards https://github.com/giantswarm/kube-prometheus-stack-app/pull/536
Latest kube-state-metrics expects these distroless images.