### PR TITLE
Replace peaceiris/hugo with hugomods/hugo versions

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -98,9 +98,10 @@ docker.io:
       - "22"
     ns1labs/flame:
       - "0.11.0"
-    peaceiris/hugo:
-      - "v0.139.3-full"
-      - "v0.146.4-full"
+    hugomods/hugo:
+      - "exts-0.139.3"
+      - "exts-0.146.4"
+      - "0.162.1"
     redis:
       - "3.2.11-alpine"
       - "4.0.9"


### PR DESCRIPTION
`peaceiris/hugo` is really slow to push hugo container images, I vote for move to `hugomods/hugo`