### PR TITLE
feat: retag kagent controller and UI images

### DIFF
--- a/images/renamed-kagent.yaml
+++ b/images/renamed-kagent.yaml
@@ -1,0 +1,6 @@
+- image: cr.kagent.dev/kagent-dev/kagent/controller
+  override_repo_name: kagent-controller
+  semver: ">= v0.9.4"
+- image: cr.kagent.dev/kagent-dev/kagent/ui
+  override_repo_name: kagent-ui
+  semver: ">= v0.9.4"


### PR DESCRIPTION
Adds kagent controller and UI images from `cr.kagent.dev` to the retagger.

Once built:
- `gsoci.azurecr.io/giantswarm/kagent-controller:<version>`
- `gsoci.azurecr.io/giantswarm/kagent-ui:<version>`

This removes the need for a Kyverno `PolicyException` on clusters running the `agentic-platform` chart with kagent enabled. The `agentic-platform` chart will be updated to set `kagent.registry: gsoci.azurecr.io/giantswarm`.