### PR TITLE
feat: add remaining kagent images (app, skills-init)

### DIFF
--- a/images/renamed-kagent.yaml
+++ b/images/renamed-kagent.yaml
@@ -4,3 +4,9 @@
 - image: cr.kagent.dev/kagent-dev/kagent/ui
   override_repo_name: kagent-ui
   semver: ">= v0.9.4"
+- image: cr.kagent.dev/kagent-dev/kagent/app
+  override_repo_name: kagent-app
+  semver: ">= v0.9.4"
+- image: cr.kagent.dev/kagent-dev/kagent/skills-init
+  override_repo_name: kagent-skills-init
+  semver: ">= v0.9.4"

--- a/images/skopeo-ghcr-io.yaml
+++ b/images/skopeo-ghcr-io.yaml
@@ -56,3 +56,4 @@ ghcr.io:
     nginxinc/nginx-unprivileged: ^1\.(2[3-9]|[3-9][0-9])-alpine$
     k8snetworkplumbingwg/multus-cni: v([0-9].){2}[0-9]-thick$
     cloudnative-pg/pgvector: ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-bookworm$
+    kagent-dev/doc2vec/mcp: ">= 1.1.14"


### PR DESCRIPTION
Adds the remaining two kagent images from `cr.kagent.dev` so the full set is retagged to `gsoci.azurecr.io/giantswarm/`:

- `kagent-app` — agent runtime
- `kagent-skills-init` — skills cloner init container

Together with the previously merged controller + ui, this allows setting `kagent.registry: gsoci.azurecr.io/giantswarm` globally in the `agentic-platform` chart — no Kyverno `PolicyException` needed.