### PR TITLE
fix: add renamed-kagent.yaml to CircleCI retag matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,7 @@ build_and_retag: &build_and_retag
             filename:
               - images/renamed-images.yaml
               - images/renamed-agentgateway.yaml
+              - images/renamed-kagent.yaml
               - images/renamed-cilium-prereleases.yaml
               - images/renamed-upbound-aws.yaml
               - images/renamed-upbound-azure.yaml


### PR DESCRIPTION
\`renamed-kagent.yaml\` was added in #1190 and #1191 but was never wired into the CircleCI \`filename\` matrix for \`retag-renamed-images\`. The retagger ran on merge and processed zero kagent images, so all four repos are absent from gsoci ACR:

- \`giantswarm/kagent-controller\`
- \`giantswarm/kagent-ui\`
- \`giantswarm/kagent-app\`
- \`giantswarm/kagent-skills-init\`

Same pattern as \`renamed-agentgateway.yaml\` which is already in the matrix.