### PR TITLE
feat: add agent-sandbox-controller image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,7 @@ build_and_retag: &build_and_retag
             filename:
               - images/renamed-images.yaml
               - images/renamed-agentgateway.yaml
+              - images/renamed-agent-sandbox.yaml
               - images/renamed-kagent.yaml
               - images/renamed-cilium-prereleases.yaml
               - images/renamed-upbound-aws.yaml

--- a/images/renamed-agent-sandbox.yaml
+++ b/images/renamed-agent-sandbox.yaml
@@ -1,0 +1,7 @@
+# agent-sandbox controller, mirrored from the upstream Kubernetes SIG registry to
+# gsoci with a flat repo name so the giantswarm/agent-sandbox chart can pull it as
+# gsoci.azurecr.io/giantswarm/agent-sandbox-controller. semver tracks stable
+# releases (upstream rc pre-releases are excluded), matching renamed-kagent.yaml.
+- image: registry.k8s.io/agent-sandbox/agent-sandbox-controller
+  override_repo_name: agent-sandbox-controller
+  semver: ">= v0.4.6"

--- a/images/renamed-agent-sandbox.yaml
+++ b/images/renamed-agent-sandbox.yaml
@@ -1,7 +1,3 @@
-# agent-sandbox controller, mirrored from the upstream Kubernetes SIG registry to
-# gsoci with a flat repo name so the giantswarm/agent-sandbox chart can pull it as
-# gsoci.azurecr.io/giantswarm/agent-sandbox-controller. semver tracks stable
-# releases (upstream rc pre-releases are excluded), matching renamed-kagent.yaml.
 - image: registry.k8s.io/agent-sandbox/agent-sandbox-controller
   override_repo_name: agent-sandbox-controller
   semver: ">= v0.4.6"


### PR DESCRIPTION
Mirrors the upstream kubernetes-sigs/agent-sandbox controller image into gsoci with a flat repo name so the new `giantswarm/agent-sandbox` chart can pull it as `gsoci.azurecr.io/giantswarm/agent-sandbox-controller`.

```yaml
- image: registry.k8s.io/agent-sandbox/agent-sandbox-controller
  override_repo_name: agent-sandbox-controller
  semver: ">= v0.4.6"
```

- Flat `override_repo_name` matches the chart's `image.repository` (same pattern as renamed-kagent.yaml / renamed-agentgateway.yaml).
- `semver: >= v0.4.6` tracks stable releases automatically (upstream `rc` pre-releases excluded), so future chart bumps find the image already mirrored.

Unblocks deploying the agent-sandbox chart and enabling its ATS smoke test.