### PR TITLE
chore: mirror ghostunnel v1.10.0 for tunnelport chart

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -36,6 +36,11 @@ docker.io:
       - "v0.27.0"
     geldata/gel:
       - "7.0"
+    # TLS-termination sidecar for tunnelport-rendered tbot pods. Mirrored so
+    # the chart can pull from gsoci and satisfy the restrict-image-registries
+    # Kyverno policy (see giantswarm/tunnelport helm/tunnelport).
+    ghostunnel/ghostunnel:
+      - "v1.10.0"
     golangci/golangci-lint:
       - "v1.23.8"
     instrumenta/conftest:


### PR DESCRIPTION
## Summary

Adds `ghostunnel/ghostunnel:v1.10.0` (Docker Hub) to the retagger sync so it is mirrored to `gsoci.azurecr.io/giantswarm/ghostunnel:v1.10.0`.

## Why

The tunnelport chart renders a ghostunnel TLS-termination sidecar onto every tbot pod, currently pulling `ghostunnel/ghostunnel:v1.10.0` directly from Docker Hub. That trips the `restrict-image-registries` Kyverno policy (only `gsoci.azurecr.io/giantswarm/*` and siblings are trusted). gsoci only had `ghostunnel:v1.5.2`. Mirroring v1.10.0 lets the chart reference the gsoci copy.

Pairs with the tunnelport chart change (giantswarm/giantswarm#36885).

Made with [Cursor](https://cursor.com)