### PR TITLE
chore: mirror kagent-tools image for kagent chart

### DIFF
--- a/images/renamed-kagent.yaml
+++ b/images/renamed-kagent.yaml
@@ -29,4 +29,4 @@
 # the restrict-image-registries Kyverno policy (see giantswarm/kagent helm/kagent).
 - image: ghcr.io/kagent-dev/kagent/tools
   override_repo_name: kagent-tools
-  semver: ">= 0.2.1"
+  semver: ">= 0.1.3"

--- a/images/renamed-kagent.yaml
+++ b/images/renamed-kagent.yaml
@@ -24,3 +24,9 @@
 - image: ghcr.io/kagent-dev/doc2vec/mcp
   override_repo_name: kagent-doc2vec-mcp
   semver: ">= 1.1.14"
+# kagent-tools is the upstream tool-server image used by the kagent chart's
+# kagent-tools subchart. Mirrored so the chart can pull from gsoci and satisfy
+# the restrict-image-registries Kyverno policy (see giantswarm/kagent helm/kagent).
+- image: ghcr.io/kagent-dev/kagent/tools
+  override_repo_name: kagent-tools
+  semver: ">= 0.2.1"


### PR DESCRIPTION
## Summary

Mirrors `ghcr.io/kagent-dev/kagent/tools` (>= 0.2.1) to `gsoci.azurecr.io/giantswarm/kagent-tools`.

## Why

The kagent chart's `kagent-tools` subchart pulls its tool-server image directly from `ghcr.io`, which trips the `restrict-image-registries` Kyverno policy in the `agentic-platform` namespace. Mirroring it to gsoci lets the chart reference the allowed registry.

Pairs with the kagent chart change (giantswarm/giantswarm#36885 — namespace-wide Kyverno cleanup).

Made with [Cursor](https://cursor.com)