### PR TITLE
fix: revert #1196 and restart retagging images from quay.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,6 +443,16 @@ build_and_retag: &build_and_retag
           - build-and-push-docker
     - filter-skopeo-tags:
         context: architect
+        name: filter-skopeo-quay-io
+        filepath: images/skopeo-quay-io.yaml
+        filters:
+          branches:
+            only:
+              - main
+        requires:
+          - build-and-push-docker
+    - filter-skopeo-tags:
+        context: architect
         name: filter-skopeo-k8s-io
         filepath: images/skopeo-registry-k8s-io.yaml
         filters:
@@ -485,6 +495,7 @@ build_and_retag: &build_and_retag
           - filter-skopeo-mcr-microsoft-com
           - filter-skopeo-public-ecr-aws
           - filter-skopeo-nvcr-io
+          - filter-skopeo-quay-io
           - filter-skopeo-k8s-io
           - filter-skopeo-k8s-io-kubernetes
         matrix:
@@ -497,6 +508,7 @@ build_and_retag: &build_and_retag
               - images/skopeo-mcr-microsoft-com.yaml.filtered
               - images/skopeo-nvcr-io.yaml.filtered
               - images/skopeo-public-ecr-aws.yaml.filtered
+              - images/skopeo-quay-io.yaml.filtered
               - images/skopeo-registry-k8s-io.yaml.filtered
               - images/skopeo-registry-k8s-io-kubernetes.yaml.filtered
     - retag-registry:
@@ -513,6 +525,7 @@ build_and_retag: &build_and_retag
           - filter-skopeo-mcr-microsoft-com
           - filter-skopeo-nvcr-io
           - filter-skopeo-public-ecr-aws
+          - filter-skopeo-quay-io
           - filter-skopeo-k8s-io
           - filter-skopeo-k8s-io-kubernetes
           - filter-skopeo-projects-registry-vmware-com
@@ -526,6 +539,7 @@ build_and_retag: &build_and_retag
               - images/skopeo-mcr-microsoft-com.yaml.filtered
               - images/skopeo-nvcr-io.yaml.filtered
               - images/skopeo-public-ecr-aws.yaml.filtered
+              - images/skopeo-quay-io.yaml.filtered
               - images/skopeo-registry-k8s-io.yaml.filtered
               - images/skopeo-registry-k8s-io-kubernetes.yaml.filtered
               - images/skopeo-projects-registry-vmware-com.yaml.filtered

--- a/images/skopeo-quay-io.yaml
+++ b/images/skopeo-quay-io.yaml
@@ -1,0 +1,48 @@
+# Docs: https://github.com/kubasobon/skopeo/blob/main/docs/skopeo-sync.1.md#yaml-file-content-used-source-for---src-yaml
+quay.io:
+  images:
+    coreos/etcd-operator:
+      - "v0.3.2"
+    coreos/flannel:
+      - "v0.11.0-amd64"
+    giantswarm/k8s-api-healthz:
+      - "1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac"
+    giantswarm/k8s-setup-network-environment:
+      - "1f4ffc52095ac368847ce3428ea99b257003d9b9"
+    jetstack/cert-manager-ingress-shim:
+      - "v0.2.5"
+    prometheus/haproxy-exporter:
+      - "v0.9.0"
+    pusher/oauth2_proxy:
+      - "v5.1.0"
+  images-by-semver:
+    argoproj/argocd: ">= v2.0.1"
+    ceph/ceph: "v16.2.5-20210708"
+    cephcsi/cephcsi: "v3.1.1 - v3.4.0"
+    cilium/cilium: ">= v1.11.2"
+    cilium/cilium-etcd-operator: ">= v2.0.7"
+    cilium/hubble-relay: ">= v1.11.2"
+    cilium/hubble-ui: ">= v0.8.5"
+    cilium/hubble-ui-backend: ">= v0.8.5"
+    cilium/cilium-envoy: ">= v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9"
+    coreos/etcd: ">= v3.3"
+    fairwinds/goldilocks: ">= v2.2.0"
+    giantswarm/amazon-k8s-cni: ">= v1.11.2"
+    jacksontj/promxy: ">= v0.0.60"
+    jetstack/cert-manager-acmesolver: ">= v1.7.3"
+    jetstack/cert-manager-cainjector: ">= v1.7.3"
+    jetstack/cert-manager-controller: ">= v1.7.3"
+    jetstack/cert-manager-ctl: ">= v1.7.3"
+    jetstack/cert-manager-webhook: ">= v1.7.3"
+    kubescape/kubescape: ">= v3.0.34"
+    oauth2-proxy/oauth2-proxy: ">= v7.2.1"
+    prometheus-operator/prometheus-config-reloader: ">= v0.62.0"
+    prometheus-operator/prometheus-operator: ">= 0.63.0"
+    prometheus/alertmanager: ">= v0.25.0"
+    prometheus/node-exporter: ">= v1.8.2"
+    uswitch/kiam: ">= v4.2.0"
+  images-by-tag-regex:
+    # Tags look like `v3.11.3-distroless`, we match v3.11 and above
+    prometheus/prometheus: ^v(3\.(1[1-9]|[2-9][0-9])|[4-9]\.[0-9]+)\.[0-9]+-distroless$
+    # Tags look like `v1.11.1-distroless`, we match v1.11 and above
+    prometheus/node-exporter: ^v(1\.(1[1-9]|[2-9][0-9])|[2-9]\.[0-9]+)\.[0-9]+-distroless$


### PR DESCRIPTION
Revert changes from https://github.com/giantswarm/retagger/pull/1196
The removed pipeline was actually retagging images FROM quay, and we still want to do it.