### PR TITLE
feat: add grafana/grafana-image-renderer

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -143,6 +143,7 @@ docker.io:
     fluent/fluent-bit: ">= 1.7.1"
     grafana/alloy: ">= v1.2.0"
     grafana/grafana: ">= 11.0.0"
+    grafana/grafana-image-renderer: ">= v5.9.0"
     grafana/k6: ">= 1.6.0"
     grafana/loki: ">= 3.0.0"
     grafana/loki-canary: ">= v3.0.0"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35703 and https://github.com/giantswarm/giantswarm/issues/35720

Grafana image renderer could:
- help with detection of broken dashboards
- allow adding dashboards or graphs to alerts