### PR TITLE
chore: Mirror prometheuscommunity/yet-another-cloudwatch-exporter

### DIFF
--- a/images/skopeo-quay-io.yaml
+++ b/images/skopeo-quay-io.yaml
@@ -40,6 +40,7 @@ quay.io:
     prometheus-operator/prometheus-operator: ">= 0.63.0"
     prometheus/alertmanager: ">= v0.25.0"
     prometheus/node-exporter: ">= v1.8.2"
+    prometheuscommunity/yet-another-cloudwatch-exporter: ">= v0.65.0"
     uswitch/kiam: ">= v4.2.0"
   images-by-tag-regex:
     # Tags look like `v3.11.3-distroless`, we match v3.11 and above


### PR DESCRIPTION
Adds the [yace](https://github.com/prometheus-community/yet-another-cloudwatch-exporter) image to retagger so it is mirrored from `quay.io` to `gsoci.azurecr.io`.

Mirrors `quay.io/prometheuscommunity/yet-another-cloudwatch-exporter` → `gsoci.azurecr.io/prometheuscommunity/yet-another-cloudwatch-exporter` via an `images-by-semver` constraint of `>= v0.65.0` (the appVersion pinned by `cloudwatch-exporter-app`, with future bumps mirrored automatically).

Needed by the new `cloudwatch-exporter-app` chart, which defaults its image registry to the Giant Swarm mirror.

Towards https://github.com/giantswarm/cloudwatch-exporter-app/pull/1

## Note

Per the retagger README, the destination repository must exist in `gsoci.azurecr.io` before the retag job runs. Please confirm `prometheuscommunity/yet-another-cloudwatch-exporter` exists there (or is auto-created on push).