### PR TITLE
feat: mirror agentgateway v2 data-plane 0.x tags

### DIFF
--- a/images/renamed-agentgateway.yaml
+++ b/images/renamed-agentgateway.yaml
@@ -4,3 +4,11 @@
 - image: cr.agentgateway.dev/agentgateway
   override_repo_name: agentgateway
   semver: ">= v1.2.0"
+# Data-plane proxy image for the kgateway-based agentgateway v2 control plane.
+# kgateway v2.2.1's deployer pins the agentgateway proxy to the 0.x tag line
+# (AgentgatewayDefaultTag, e.g. 0.12.0 in v2.2.1); these do not match the
+# ">= v1.2.0" rule above. Mirror the 0.x data-plane tags so Giant Swarm clusters
+# can pull the proxy from gsoci. See giantswarm/agentgateway (v2 migration).
+- image: cr.agentgateway.dev/agentgateway
+  override_repo_name: agentgateway
+  semver: ">= 0.12.0 < 1.0.0"


### PR DESCRIPTION
## What

Adds a retagger rule to mirror the agentgateway **data-plane** proxy image on the `0.x` tag line (`>= 0.12.0 < 1.0.0`) from `cr.agentgateway.dev/agentgateway` → `gsoci.azurecr.io/giantswarm/agentgateway`.

## Why

`giantswarm/agentgateway` is migrating its packaged chart to the upstream **v2** (kgateway-based) control plane (`v2.2.1`). In v2 the controller acts as a deployer: for `agentgateway`-class Gateways, kgateway v2.2.1 renders the data-plane proxy from a **hardcoded** image constant — `cr.agentgateway.dev/agentgateway:<AgentgatewayDefaultTag>`, where `AgentgatewayDefaultTag = 0.12.0` (see `pkg/deployer/wellknown.go` + `pkg/kgateway/deployer/agentgateway_parameters.go`). This is the `0.x` data-plane line, **not** the `v1.x`/`v2.x` release line.

The existing rule only mirrors `>= v1.2.0`, so `0.12.0` is not mirrored and `gsoci.azurecr.io/giantswarm/agentgateway:0.12.0` does not exist today. This PR makes the v2 data-plane image available on gsoci so a follow-up in `giantswarm/agentgateway` can point the data plane (via an `AgentgatewayParameters` override) at the mirror instead of pulling directly from `cr.agentgateway.dev`.

## Notes

- The new rule is a second list entry for the same image with a distinct semver range; it shares the destination repo (`giantswarm/agentgateway`) with the existing `v1.x`/`v2.x` rule — the tag sets are disjoint, so no tag collides.
- Owned by @giantswarm/team-honeybadger — leaving this for your review; the agentgateway v2 migration does not block on it (that PR references the existing upstream image which already exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)