### PR TITLE
feat: mirror dicebear/api image to gsoci

### DIFF
--- a/images/renamed-images.yaml
+++ b/images/renamed-images.yaml
@@ -964,3 +964,8 @@
 - image: xpkg.upbound.io/upbound/function-cidr
   semver: ">= 0.5.0"
   override_repo_name: crossplane-contrib-function-cidr
+# DiceBear avatar API, self-hosted to render agent avatar icons.
+# See giantswarm/giantswarm#37211.
+- image: docker.io/dicebear/api
+  override_repo_name: dicebear-api
+  semver: ">= 4.9.0"


### PR DESCRIPTION
## What

Adds an entry to `images/renamed-images.yaml` to mirror the upstream DiceBear avatar HTTP API image into our registry:

- `docker.io/dicebear/api` → `gsoci.azurecr.io/giantswarm/dicebear-api` (`semver: ">= 4.9.0"`)

## Why

Prerequisite for a self-hosted DiceBear avatar renderer, which will generate deterministic agent avatar icons. The renderer's Helm chart must pull the image from `gsoci` (never Docker Hub directly) to satisfy the `restrict-image-registries` Kyverno policy.

The `dicebear/api` v4.x image line is DiceBear-10-only, which is the version the feature targets.

Ref: giantswarm/giantswarm#37211
PRD: https://github.com/giantswarm/bumblebee-plans/tree/main/agent-avatar-icon