### PR TITLE
fix: move docker.io/coredns to regex and remove obsolete sync from k8s.io

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -12,22 +12,6 @@ docker.io:
       - "8.1.1911"
     cibuilds/github:
       - "0.12"
-    coredns/coredns:
-      - "1.11.1"
-      - "1.11.3"
-      - "1.11.4"
-      - "1.12.0"
-      - "1.12.1"
-      - "1.12.2"
-      - "1.12.3"
-      - "1.13.0"
-      - "1.13.1"
-      - "1.13.2"
-      - "1.14.0"
-      - "1.14.1"
-      - "1.14.2"
-      - "1.14.3"
-      - "1.14.4"
     docker:
       - "18.09.1"
     elasticsearch:
@@ -129,6 +113,7 @@ docker.io:
     busybox: ">= 1.31.0"
     cfssl/cfssl: ">= 1.6.1"
     clastix/cluster-api-control-plane-provider-kamaji: ">= v0.16.0"
+    coredns/coredns: ">= 1.14.0"
     crossplane/crossplane: ">= v1.9.1"
     curlimages/curl: ">= 7.67.0"
     ealen/echo-server: ">=0.5.0"

--- a/images/skopeo-registry-k8s-io.yaml
+++ b/images/skopeo-registry-k8s-io.yaml
@@ -12,19 +12,6 @@ registry.k8s.io:
     cluster-api-azure/cluster-api-azure-controller: ">= v0.5.0"
     cluster-api-gcp/cluster-api-gcp-controller: ">= v1.0.2"
     cluster-proportional-autoscaler-amd64: ">= 1.6.0"
-    # We have to ensure that etcd is available to CAPI clusters - we set
-    # `clusterConfiguration.imageRepository=docker.io/giantswarm` (e.g. in
-    # cluster-aws:
-    # https://github.com/giantswarm/cluster-aws/search?q=imageRepository%3A) and
-    # that means `kubeadm join` will use the images from our Docker Hub repo.
-    # Kubernetes does not support tag suffixes, so we must publish images as
-    # `docker.io/giantswarm/coredns:v1.10.0`. And those must not conflict with the
-    # `coreos/coreos` tags - since those use a suffix, we're fine here.
-    #
-    # Once https://github.com/kubernetes/kubeadm/issues/2603 (kubeadm shouldn't
-    # pull the coredns image at all since we skip the coredns addon and instead
-    # install it using our app platform) is fixed, we can remove this:
-    coredns/coredns: ">= v1.8.0"
     descheduler/descheduler: ">= v0.31.0"
     dns/k8s-dns-node-cache: ">= 1.21.1"
     etcd: ">= v3.5.4-0"


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>
