### PR TITLE
chore: stop mirroring conftest to gsoci

### DIFF
--- a/images/skopeo-docker-io.yaml
+++ b/images/skopeo-docker-io.yaml
@@ -30,9 +30,6 @@ docker.io:
       - "v1.10.0"
     golangci/golangci-lint:
       - "v1.23.8"
-    instrumenta/conftest:
-      - "v0.18.1"
-      - "v0.21.0"
     janeczku/go-dnsmasq:
       - "release-1.0.7"
     jimschubert/swagger-codegen-cli:
@@ -149,7 +146,6 @@ docker.io:
     localstack/localstack: ">= 4.7.0"
     mikefarah/yq: ">= 4.31.2"
     mintel/dex-k8s-authenticator: ">= 1.4.0"
-    openpolicyagent/conftest: ">= v0.25.0"
     opensearchproject/opensearch: ">= v3.2.0"
     prom/blackbox-exporter: ">= v0.23.0"
     prom/prometheus: ">= 2.41.0"


### PR DESCRIPTION
Last cleanup item from giantswarm/roadmap#4066.

`conftest` was mirrored to gsoci solely for the `helm-conftest` step in architect-orb's `push-to-app-catalog` job. That step was removed in architect-orb v6.3.2 after a conftest upgrade broke it, and it was never restored — the third-party [deprek8ion](https://github.com/swade1987/deprek8ion) policies it ran have been unmaintained since 2021 and only covered Kubernetes API deprecations up to 1.22, while app-build-suite already runs kube-linter over the same manifests.

The binary has since been removed from all three images that carried it:

| Image | PR |
|---|---|
| `architect` | giantswarm/architect#1391 |
| `app-build-suite` (`-circleci`) | giantswarm/app-build-suite#581 |
| `app-test-suite` (`-circleci`) | giantswarm/app-test-suite#699 |

## Verified before removing

Org-wide code search for `giantswarm/conftest` returns exactly one hit: a hardcoded repository-name list in `honeybadger-notepad/acr-replica-crawler/main.py`. That's a crawler inventory, not a consumer that pulls the image. No Dockerfile, chart, or pipeline references it.

## Scope

Removes two entries:

- the legacy pinned `instrumenta/conftest` tags (`v0.18.1`, `v0.21.0`) — that upstream repo has been renamed to `openpolicyagent` for years
- the `openpolicyagent/conftest: ">= v0.25.0"` semver range

**Already-mirrored tags remain pullable** — this only stops new ones from being synced, so nothing that somehow still depends on an existing tag breaks.