### PR TITLE
fix: mirror golang-adk from ghcr.io — upstream left cr.kagent.dev after 0.9.9

### DIFF
--- a/images/renamed-kagent.yaml
+++ b/images/renamed-kagent.yaml
@@ -15,10 +15,14 @@
 # agentImage.repository with "golang-adk", so the destination name must be bare "golang-adk".
 # Two entries: plain semver tags (0.9.x) and the -full variants (used when git skills are present).
 # See https://github.com/kagent-dev/kagent/issues/2018
-- image: cr.kagent.dev/kagent-dev/kagent/golang-adk
+# Source is ghcr.io: upstream stopped publishing golang-adk to cr.kagent.dev
+# after 0.9.9 (the other kagent images still live there), which silently
+# stalled this mirror while declarative go agents on kagent >= 0.9.10
+# compose gsoci golang-adk:<controller version> and fail to pull.
+- image: ghcr.io/kagent-dev/kagent/golang-adk
   override_repo_name: golang-adk
   semver: ">= v0.9.4"
-- image: cr.kagent.dev/kagent-dev/kagent/golang-adk
+- image: ghcr.io/kagent-dev/kagent/golang-adk
   override_repo_name: golang-adk
   tag_or_pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+-full$"
 - image: ghcr.io/kagent-dev/doc2vec/mcp


### PR DESCRIPTION
Upstream stopped publishing `golang-adk` to `cr.kagent.dev` after 0.9.9 (the other kagent images still live there), so this mirror silently stalled: gsoci has golang-adk up to 0.9.9 only, while kagent 0.9.10+ controllers compose `gsoci.azurecr.io/giantswarm/golang-adk:<controller version>` for declarative go agents — every such agent pod fails with ErrImagePull (hit live on kagent 0.9.12: `golang-adk:0.9.12 not found`).

`ghcr.io/kagent-dev/kagent/golang-adk` carries all tags including the `-full` variants (verified 0.9.9, 0.9.12 and 0.9.12-full exist there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)